### PR TITLE
Add .editorconfig with two-space indents to match code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This will automatically configure many editors to use two space indents, making it easier for people to contribute who normally use four spaces for Python code.