### PR TITLE
Add ad-hoc SSL support

### DIFF
--- a/datanode/docker/Dockerfile_storageapi
+++ b/datanode/docker/Dockerfile_storageapi
@@ -37,7 +37,7 @@ FROM python:2
 
 WORKDIR /usr/src/app
 
-RUN pip install --no-cache-dir python-dateutil kazoo flask PyJWT djangorestframework cryptography
+RUN pip install --no-cache-dir python-dateutil kazoo flask PyJWT djangorestframework cryptography pyopenssl
 
 COPY . .
 

--- a/datanode/docker/README.md
+++ b/datanode/docker/README.md
@@ -71,3 +71,10 @@ docker run -e INTERUSS_PUBLIC_KEY="${INTERUSS_PUBLIC_KEY}" \
   -p 8121:8121 \
   -d interussplatform/data_node
 ```
+
+## SSL
+
+To use TLS encryption for all endpoints, add `--ssladhoc` to STORAGE_API_ARGS.  So, for the
+stand-alone test node example above, set `-e STORAGE_API_ARGS="-t test --ssladhoc"`.  This will
+enable TLS encryption using ad hoc certificates.  As such, clients will not be assured of the
+identity of the server, but traffic will be protected in transit.

--- a/datanode/docker/docker-compose_pybasetest.yaml
+++ b/datanode/docker/docker-compose_pybasetest.yaml
@@ -25,7 +25,7 @@ version: '3.6'
 services:
 
   datanode:
-    image: data_node
+    image: interussplatform/data_node
     ports:
       - 8121:8121
     expose:

--- a/datanode/docker/docker-compose_storageapitest.yaml
+++ b/datanode/docker/docker-compose_storageapitest.yaml
@@ -57,7 +57,7 @@ services:
       - ZOO_SERVERS=server.1=localzoo:2888:3888 server.2=zoo2:2888:3888 server.3=0.0.0.0:2888:3888
 
   storage_api:
-    image: storage_api
+    image: interussplatform/storage_api
     ports:
       - ${INTERUSS_API_PORT}:${INTERUSS_API_PORT}
     environment:

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -485,6 +485,13 @@ def InitializeConnection(argv):
       help='Force testing mode with test data located in specific test id  '
       '[or env variable INTERUSS_TESTID]',
       metavar='TESTID')
+  parser.add_option(
+      '-a',
+      '--ssladhoc',
+      action='store_true',
+      dest='ssladhoc',
+      default=False,
+      help='Enable ad-hoc TLS encryption')
   (options, args) = parser.parse_args(argv)
   del args
   if options.verbose or os.environ.get('INTERUSS_VERBOSE'):
@@ -498,7 +505,7 @@ def InitializeConnection(argv):
     TESTID = os.getenv('INTERUSS_TESTID', options.testid)
     wrapper.set_testmode(TESTID)
     wrapper.delete_testdata(TESTID)
-  return options.server, options.port
+  return options.server, options.port, options.ssladhoc
 
 
 def TerminateConnection():
@@ -514,9 +521,10 @@ def main(argv):
     log.debug(
         """Instantiated application, parsing commandline
       %s and initializing connection...""", str(argv))
-    host, port = InitializeConnection(argv)
+    host, port, ssl_adhoc = InitializeConnection(argv)
     log.info('Starting webserver...')
-    webapp.run(host=host, port=int(port))
+    webapp.run(host=host, port=int(port),
+               ssl_context='adhoc' if ssl_adhoc else None)
 
 
 # this is what starts everything


### PR DESCRIPTION
Adds a flag to turn on ad-hoc SSL support in the web app which turns all endpoints into https.

Also fixes the two docker compose yaml files to use the fully-qualified image names.