### PR TITLE
Bug fixes for slippy, dates, and OAuth key

### DIFF
--- a/datanode/docker/datanode_entrypoint.sh
+++ b/datanode/docker/datanode_entrypoint.sh
@@ -34,7 +34,11 @@ echo "syncLimit=$ZOO_SYNC_LIMIT" >> "$ZOO_CONFIG"
 echo "maxClientCnxns=$ZOO_MAX_CLIENT_CNXNS" >> "$ZOO_CONFIG"
 
 for server in $ZOO_SERVERS; do
-    echo "$server" >> "$ZOO_CONFIG"
+    if [[ $server = "server.${ZOO_MY_ID}"* ]]; then
+        echo "$server" | sed 's/=[0-9.]*:/=0.0.0.0:/' >> "$ZOO_CONFIG"
+    else
+        echo "$server" >> "$ZOO_CONFIG"
+    fi
 done
 
 # Write myid

--- a/datanode/docker/datanode_entrypoint.sh
+++ b/datanode/docker/datanode_entrypoint.sh
@@ -35,7 +35,7 @@ echo "maxClientCnxns=$ZOO_MAX_CLIENT_CNXNS" >> "$ZOO_CONFIG"
 
 for server in $ZOO_SERVERS; do
     if [[ $server = "server.${ZOO_MY_ID}"* ]]; then
-        echo "$server" | sed 's/=[0-9.]*:/=0.0.0.0:/' >> "$ZOO_CONFIG"
+      echo "$server" | sed 's/server\.\([0-9]\+\)=[^:]*:/server.\1=0.0.0.0:/'
     else
         echo "$server" >> "$ZOO_CONFIG"
     fi

--- a/datanode/src/README.md
+++ b/datanode/src/README.md
@@ -4,6 +4,8 @@
     one class of interest: USSMetadataManager with get/set/delete operations and
     an initialization with a Zookeeper connection string.
 
+*   uss_metadata.py - information wrapper for the actual JSON data structure.
+
 *   storage_api.py - Web Service API for the Zookeeper library. It will
     start a web service and serve GET/PUT/DELETE on
     /GridCellMetaData/<z>/<x>/<y>, which wraps directly to the

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -84,7 +84,9 @@ webapp = Flask(__name__)  # Global object serving the API
 def Status():
   # just a quick status checker, not really a health check
   log.debug('Status handler instantiated...')
-  return _FormatResult({'status': 'success', 'message': 'OK'})
+  return _FormatResult({'status': 'success',
+                        'message': 'OK',
+                        'version': VERSION})
 
 
 @webapp.route('/introspect', methods=['GET'])

--- a/datanode/src/storage_api_test.py
+++ b/datanode/src/storage_api_test.py
@@ -101,9 +101,9 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     r = self.app.get('/slippy/11?coords=1,1')
     self.assertEqual(r.status_code, 200)
     j = json.loads(r.data)
-    self.assertEqual(11, j['data']['grid_cells'][0]['zoom'], 11)
-    self.assertEqual(1029, j['data']['grid_cells'][0]['x'], 1029)
-    self.assertEqual(1018, j['data']['grid_cells'][0]['y'], 1018)
+    self.assertEqual(11, j['data']['grid_cells'][0]['zoom'])
+    self.assertEqual(1029, j['data']['grid_cells'][0]['x'])
+    self.assertEqual(1018, j['data']['grid_cells'][0]['y'])
     self.assertEqual('http://tile.openstreetmap.org/11/1029/1018.png',
                      j['data']['grid_cells'][0]['link'])
     r = self.app.get('/slippy/10?coords=37.408959,-122.053834')

--- a/datanode/src/storage_api_test.py
+++ b/datanode/src/storage_api_test.py
@@ -51,7 +51,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     result = self.app.get('/introspect?access_token=NOTVALID')
     self.assertEqual(result.status_code, 403)
     result = self.app.get('/introspect', headers={'access_token': 'NOTVALID'})
-    self.assertEqual(result.status_code, 403)
+    self.assertEqual(result.status_code, 400)
 
   def testIntrospectWithExpiredToken(self):
     self.assertIsNotNone(os.environ.get('FIMS_AUTH'))
@@ -67,7 +67,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     # pylint: disable=line-too-long
     self.assertIsNotNone(os.environ.get('FIMS_AUTH'))
     self.assertIsNotNone(os.environ.get('INTERUSS_PUBLIC_KEY'))
-    endpoint = 'https://utmbeta.arc.nasa.gov//fimsAuthServer/oauth/token?grant_type=client_credentials'
+    endpoint = 'https://utmalpha.arc.nasa.gov//fimsAuthServer/oauth/token?grant_type=client_credentials'
     headers = {'Authorization': 'Basic ' + os.environ.get('FIMS_AUTH', '')}
     r = requests.post(endpoint, headers=headers)
     self.assertEqual(r.status_code, 200)
@@ -88,9 +88,9 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     self.assertEqual(result.status_code, 400)
     result = self.app.get('/slippy/11?coords=1,1a')
     self.assertEqual(result.status_code, 400)
-    result = self.app.get('/slippy/11?coords=181,1')
+    result = self.app.get('/slippy/11?coords=91,1')
     self.assertEqual(result.status_code, 400)
-    result = self.app.get('/slippy/11?coords=1,91')
+    result = self.app.get('/slippy/11?coords=1,181')
     self.assertEqual(result.status_code, 400)
     result = self.app.get('/slippy/21?coords=1,1')
     self.assertEqual(result.status_code, 400)
@@ -101,35 +101,35 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     r = self.app.get('/slippy/11?coords=1,1')
     self.assertEqual(r.status_code, 200)
     j = json.loads(r.data)
-    self.assertEqual(j['data']['tiles'][0], [11, 1029, 1018])
-    self.assertEqual(j['data']['links'][0],
-                    'http://tile.openstreetmap.org/11/1029/1018.png')
-    r = self.app.get('/slippy/10?coords=37.203335,-80.599481')
-    r = self.app.get('/slippy/10?coords=37.203335,-80.599481')
+    self.assertEqual(11, j['data']['grid_cells'][0]['zoom'], 11)
+    self.assertEqual(1029, j['data']['grid_cells'][0]['x'], 1029)
+    self.assertEqual(1018, j['data']['grid_cells'][0]['y'], 1018)
+    self.assertEqual('http://tile.openstreetmap.org/11/1029/1018.png',
+                     j['data']['grid_cells'][0]['link'])
+    r = self.app.get('/slippy/10?coords=37.408959,-122.053834')
     self.assertEqual(r.status_code, 200)
     j = json.loads(r.data)
-    self.assertEqual(j['data']['tiles'][0], [10, 617, 919])
-    self.assertEqual(j['data']['links'][0],
-                    'http://tile.openstreetmap.org/10/617/919.png')
+    self.assertEqual(10, j['data']['grid_cells'][0]['zoom'])
+    self.assertEqual(164, j['data']['grid_cells'][0]['x'])
+    self.assertEqual(397, j['data']['grid_cells'][0]['y'])
+    self.assertEqual('http://tile.openstreetmap.org/10/164/397.png',
+                     j['data']['grid_cells'][0]['link'])
     r = self.app.get('/slippy/11?coords=37.203335,-80.599481')
-    self.assertEqual(json.loads(r.data)['data']['tiles'][0], [11, 1235, 1838])
+    self.assertEqual('http://tile.openstreetmap.org/11/565/795.png',
+                     json.loads(r.data)['data']['grid_cells'][0]['link'])
     r = self.app.get('/slippy/12?coords=37.203335,-80.599481')
-    self.assertEqual(json.loads(r.data)['data']['tiles'][0], [12, 2471, 3676])
+    self.assertEqual('http://tile.openstreetmap.org/12/1130/1591.png',
+                     json.loads(r.data)['data']['grid_cells'][0]['link'])
     r = self.app.get('/slippy/13?coords=37.203335,-80.599481')
-    self.assertEqual(json.loads(r.data)['data']['tiles'][0], [13, 4942, 7353])
-    r = self.app.get('/slippy/14?coords=37.203335,-80.599481')
-    self.assertEqual(json.loads(r.data)['data']['tiles'][0], [14, 9885, 14706])
-    r = self.app.get('/slippy/15?coords=37.203335,-80.599481')
-    self.assertEqual(json.loads(r.data)['data']['tiles'][0], [15, 19770, 29413])
-    r = self.app.get('/slippy/16?coords=37.203335,-80.599481')
-    self.assertEqual(json.loads(r.data)['data']['tiles'][0], [16, 39540, 58826])
-    r = self.app.get('/slippy/17?coords=37.203335,-80.599481')
-    self.assertEqual(json.loads(r.data)['data']['tiles'][0], [17, 79081, 117653])
-    r = self.app.get('/slippy/11?coords=0,0,1,1')
-    self.assertEqual(r.status_code, 200)
+    self.assertEqual('http://tile.openstreetmap.org/13/2261/3182.png',
+                     json.loads(r.data)['data']['grid_cells'][0]['link'])
     j = json.loads(r.data)
-    self.assertEqual(len(j['data']['tiles']), 2)
-    self.assertEqual(len(j['data']['links']), 2)
+    self.assertEqual(
+      j, json.loads(self.app.get(
+        '/slippy/13?coords=37.203335,-80.599481,37.20334,-80.59948').data))
+    r = self.app.get('/slippy/11?coords=0,0,1,1,2,2,3,3')
+    self.assertEqual(r.status_code, 200)
+    self.assertEqual(len(json.loads(r.data)['data']['grid_cells']), 4)
 
   def testMultipleSuccessfulEmptyRandomGets(self):
     self.CheckEmptyGridCell(self.app.get('/GridCellMetaData/1/1/1'))

--- a/datanode/src/storage_interface_test.py
+++ b/datanode/src/storage_interface_test.py
@@ -227,10 +227,17 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
       token = s['sync_token']
       self.assertEqual(s['status'], 'success')
       o = s['data']['operators'][0]
-      self.assertEqual(parser.parse(test[0]),
-                       parser.parse(o['minimum_operation_timestamp']))
-      self.assertEqual(parser.parse(test[1]),
-                       parser.parse(o['maximum_operation_timestamp']))
+      # Fix up the test cases to compare, this isn't what is sent to the api
+      mintest = test[0]
+      maxtest = test[1]
+      if len(maxtest) <= 10:
+        maxtest = maxtest + 'T00:00:00Z'
+      if not ('+' in mintest[-6:] or '-' in mintest[-6:] or 'Z' in mintest[-6:]):
+        mintest += 'Z'
+      if not ('+' in maxtest[-6:] or '-' in maxtest[-6:] or 'Z' in maxtest[-6:]):
+        maxtest += 'Z'
+      self.assertAlmostEqual(0, (parser.parse(mintest) - parser.parse(o['minimum_operation_timestamp'])).total_seconds(), 0)
+      self.assertAlmostEqual(0, (parser.parse(maxtest) - parser.parse(o['maximum_operation_timestamp'])).total_seconds(), 0)
     # Make sure everything is clean
     self.mm.delete_testdata()
     return

--- a/datanode/src/uss_metadata.py
+++ b/datanode/src/uss_metadata.py
@@ -1,0 +1,139 @@
+"""The InterUSS Platform Data Node storage API server.
+This flexible and distributed system is used to connect multiple USSs operating
+in the same general area to share safety information while protecting the
+privacy of USSs, businesses, operator and consumers. The system is focused on
+facilitating communication amongst actively operating USSs with no details about
+UAS operations stored or processed on the InterUSS Platform.
+
+A data node contains all of the API, logic, and data consistency infrastructure
+required to perform CRUD (Create, Read, Update, Delete) operations on specific
+grid cells. Multiple data nodes can be executed to increase resilience and
+availability. This is achieved by a stateless API to service USSs, an
+information interface to translate grid cell USS information into the correct
+data storage format, and an information consistency store to ensure data is up
+to date.
+
+This module is the information wrapper for the actual JSON data structure.
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import datetime
+import json
+import logging
+import pytz
+from dateutil import parser
+
+# logging is our log infrastructure used for this application
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+log = logging.getLogger('InterUSS_DataNode_InformationInterface')
+
+
+class USSMetadata(object):
+  """Data structure for the metadata stored for USS entries in a GridCell.
+
+  Format: {version: <version>, timestamp: <last_updated>, operators:
+    [{uss: <ussid>, scope: <used_for_obtaining_oauth_tokens>,
+    version: <last_version_for_this_uss>, timestamp: <last_updated>,
+    operation_endpoint: <endpoint_to_retrieve_operations_in_this_grid>,
+    operation_format: <output_format_of_uas_operations>,
+    minimum_operation_timestamp: <lowest_start_time_of_operations_in_this_cell>,
+    maximum_operation_timestamp: <highest_end_time_of_operations_in_this_cell>
+    },
+      ...other USSs as appropriate... ]
+  }
+
+  """
+
+  def __init__(self, content=None):
+    # Parse the metadata or create a new one if none
+    if content:
+      m = json.loads(content)
+      self.version = m['version']
+      self.timestamp = m['timestamp']
+      self.operators = m['operators']
+    else:
+      self.version = 0
+      self.timestamp = self.format_ts()
+      self.operators = []
+
+  def __str__(self):
+    return str(self.to_json())
+
+  def to_json(self):
+    return {
+      'version': self.version,
+      'timestamp': self.timestamp,
+      'operators': self.operators
+    }
+
+  def upsert_operator(self, uss_id, ws_scope, operation_format, operation_ws,
+    earliest, latest):
+    """Inserts or updates an operation, with uss_id as the key.
+
+    Args:
+      uss_id: plain text identifier for the USS,
+      ws_scope: scope to use to obtain OAuth token,
+      operation_format: output format for operation ws (i.e. NASA, GUTMA),
+      operation_ws: submitting USS endpoint where all flights in
+        this cell can be retrieved from,
+      earliest: lower bound of active or planned flight timestamp,
+        used for quick filtering conflicts.
+      latest: upper bound of active or planned flight timestamp,
+        used for quick filtering conflicts.
+    Returns:
+      true if valid, false if not
+    """
+    # Remove the existing operator, if any
+    self.remove_operator(uss_id)
+    try:
+      earliest_operation = parser.parse(earliest)
+      if earliest_operation.tzinfo is None:
+        earliest_operation = earliest_operation.replace(tzinfo=pytz.utc)
+      latest_operation = parser.parse(latest)
+      if latest_operation.tzinfo is None:
+        latest_operation = latest_operation.replace(tzinfo=pytz.utc)
+      if earliest_operation >= latest_operation:
+        raise ValueError
+    except (TypeError, ValueError, OverflowError):
+      log.error('Invalid date format/values for operators %s, %s',
+                earliest, latest)
+      return False
+    # Now add the new record
+    operator = {
+      'uss': uss_id,
+      'scope': ws_scope,
+      'version': self.version,
+      'timestamp': self.format_ts(),
+      'operation_endpoint': operation_ws,
+      'operation_format': operation_format,
+      'minimum_operation_timestamp': self.format_ts(earliest_operation),
+      'maximum_operation_timestamp': self.format_ts(latest_operation)
+    }
+    self.operators.append(operator)
+    self.timestamp = self.format_ts()
+    return True
+
+  def remove_operator(self, uss_id):
+    self.version += 1
+    # Remove the existing operator, if any
+    self.operators[:] = [
+      d for d in self.operators if d.get('uss').upper() != uss_id.upper()
+    ]
+    self.timestamp = self.format_ts()
+
+  def format_ts(self, timestamp=None):
+    r = datetime.datetime.now(pytz.utc) if timestamp is None else timestamp
+    r = r.astimezone(pytz.utc)
+    return r.isoformat()


### PR DESCRIPTION
Added uss_metadata.py to separate logic from data structure for better maintenance,
Updated docker script to 0.0.0.0 out local servers as required for Zookeeper,
Slippy errors fixe, input standardized to CSV of lat,lon, and output more JSON friendly,
Date parsing is more robust, handling timezone aware and timezone unaware dates,
Updated OAuth public key parsing to handle the way they are formatted as environment variables,
Updated version to 1.0.1 to cover changes in slippy api, Swaggerhub updates in progress.
