### PR TITLE
Storage interface changes to support multi-grid

### DIFF
--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -42,6 +42,7 @@ import slippy_util
 # Kazoo is the zookeeper wrapper for python
 from kazoo.client import KazooClient
 from kazoo.exceptions import BadVersionError
+from kazoo.exceptions import NoNodeError
 from kazoo.exceptions import RolledBackError
 from kazoo.handlers.threading import KazooTimeoutError
 from kazoo.protocol.states import KazooState
@@ -411,8 +412,11 @@ class USSMetadataManager(object):
     path = '%s/%s/%s/%s/%s' % (GRID_PATH, str(z), str(x), str(y),
                                USS_METADATA_FILE)
     log.debug('Getting metadata from zookeeper@%s...', path)
-    self.zk.ensure_path(path)
-    c, m = self.zk.get(path)
+    try:
+      c, m = self.zk.get(path)
+    except NoNodeError:
+      self.zk.ensure_path(path)
+      c, m = self.zk.get(path)
     if c:
       log.debug('Received raw content and metadata from zookeeper: %s', c)
     if m:

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -41,7 +41,8 @@ import slippy_util
 
 # Kazoo is the zookeeper wrapper for python
 from kazoo.client import KazooClient
-from kazoo.exceptions import LockTimeout
+from kazoo.exceptions import BadVersionError
+from kazoo.exceptions import RolledBackError
 from kazoo.handlers.threading import KazooTimeoutError
 from kazoo.protocol.states import KazooState
 
@@ -56,7 +57,6 @@ TEST_BASE_PREFIX = '/test/'
 USS_METADATA_FILE = '/manifest'
 BAD_CHARACTER_CHECK = '\';(){}[]!@#$%^&*|"<>'
 CONNECTION_TIMEOUT = 2.5  # seconds
-LOCK_TIMEOUT = 2.5  # seconds
 DEFAULT_CONNECTION = 'localhost:2181'
 GRID_PATH = USS_BASE_PREFIX
 
@@ -171,9 +171,9 @@ class USSMetadataManager(object):
           m = uss_metadata.USSMetadata(content)
           status = 200
           result = {
-              'status': 'success',
-              'sync_token': metadata.last_modified_transaction_id,
-              'data': m.to_json()
+            'status': 'success',
+            'sync_token': metadata.last_modified_transaction_id,
+            'data': m.to_json()
           }
         except ValueError:
           status = 424
@@ -186,7 +186,7 @@ class USSMetadataManager(object):
     return result
 
   def set(self, z, x, y, sync_token, uss_id, ws_scope, operation_format,
-          operation_ws, earliest_operation, latest_operation):
+    operation_ws, earliest_operation, latest_operation):
     """Sets the metadata for a GridCell.
 
     Writes data, using the snapshot token for confirming data
@@ -212,7 +212,6 @@ class USSMetadataManager(object):
     status = 500
     if slippy_util.validate_slippy(z, x, y):
       # first we have to get the cell
-      status = 0
       (content, metadata) = self._get_raw(z, x, y)
       if metadata:
         # Quick check of the token, another is done on the actual set to be sure
@@ -223,11 +222,11 @@ class USSMetadataManager(object):
             log.debug('Setting metadata for %s...', uss_id)
             if not m.upsert_operator(uss_id, ws_scope, operation_format,
                                      operation_ws, earliest_operation,
-                                     latest_operation):
+                                     latest_operation, z, x, y):
               log.error('Failed setting operator for %s with token %s...',
                         uss_id, str(sync_token))
               raise ValueError
-            status = self._set_raw(z, x, y, m, uss_id, sync_token)
+            status = self._set_raw(z, x, y, m, metadata.version)
           except ValueError:
             status = 424
         else:
@@ -263,8 +262,7 @@ class USSMetadataManager(object):
           m = uss_metadata.USSMetadata(content)
           m.remove_operator(uss_id)
           # TODO(pelletierb): Automatically retry on delete
-          status = self._set_raw(z, x, y, m, uss_id,
-                                 metadata.last_modified_transaction_id)
+          status = self._set_raw(z, x, y, m, metadata.version)
         except ValueError:
           status = 424
       else:
@@ -275,12 +273,125 @@ class USSMetadataManager(object):
       # Success, now get the metadata back to send back
       (content, metadata) = self._get_raw(z, x, y)
       result = {
-          'status': 'success',
-          'sync_token': metadata.last_modified_transaction_id,
-          'data': m.to_json()
+        'status': 'success',
+        'sync_token': metadata.last_modified_transaction_id,
+        'data': m.to_json()
       }
     else:
       result = self._format_status_code_to_jsend(status)
+    return result
+
+  def get_multi(self, z, grids):
+    """Gets the metadata and snapshot token for a GridCell.
+
+    Reads data from zookeeper, including a snapshot token. The
+    snapshot token is used as a reference when writing to ensure
+    the data has not been updated between read and write.
+
+    Args:
+      z: zoom level in slippy tile format
+      grids: list of (x,y) tiles to retrieve
+    Returns:
+      JSend formatted response (https://labs.omniti.com/labs/jsend)
+    """
+    try:
+      metas, syncs = self._get_multi_raw(z, grids)
+      log.debug('Found sync token %s for %d grids...',
+                self._hash_sync_tokens(syncs), len(syncs))
+      result = {
+        'status': 'success',
+        'sync_token': self._hash_sync_tokens(syncs),
+        'data': metas.to_json()
+      }
+    except ValueError as e:
+      result = self._format_status_code_to_jsend(400, e.message)
+    except IndexError as e:
+      result = self._format_status_code_to_jsend(404, e.message)
+    return result
+
+  def set_multi(self, z, grids, sync_token, uss_id, ws_scope, operation_format,
+    operation_ws, earliest_operation, latest_operation):
+    """Sets multiple GridCells metadata at once.
+
+    Writes data, using the hashed snapshot token for confirming data
+    has not been updated since it was last read.
+
+    Args:
+      z: zoom level in slippy tile format
+      grids: list of (x,y) tiles to update
+      sync_token: token retrieved in the original get_multi,
+      uss_id: plain text identifier for the USS,
+      ws_scope: scope to use to obtain OAuth token,
+      operation_format: output format for operation ws (i.e. NASA, GUTMA),
+      operation_ws: submitting USS endpoint where all flights in
+        this cell can be retrieved from,
+      earliest_operation: lower bound of active or planned flight timestamp,
+        used for quick filtering conflicts.
+      latest_operation: upper bound of active or planned flight timestamp,
+        used for quick filtering conflicts.
+    Returns:
+      JSend formatted response (https://labs.omniti.com/labs/jsend)
+    """
+    log.debug('Setting multiple grid metadata for %s...', uss_id)
+    try:
+      # first, get the grids affected
+      metas, syncs = self._get_multi_raw(z, grids)
+      # Quick check of the token, another is done on the actual set to be sure
+      #    but this check fails early and fast
+      log.debug('Found sync token %d for %d grids...',
+                self._hash_sync_tokens(syncs), len(syncs))
+      if str(self._hash_sync_tokens(syncs)) == str(sync_token):
+        log.debug('Composite sync_token matches, continuing...')
+        self._set_multi_raw(z, grids, syncs, uss_id, ws_scope, operation_format,
+                            operation_ws, earliest_operation, latest_operation)
+        log.debug('Completed updating multiple grids...')
+      else:
+        raise KeyError('Composite sync_token has changed')
+      new_metas, new_syncs = self._get_multi_raw(z, grids)
+      result = {
+        'status': 'success',
+        'sync_token': self._hash_sync_tokens(new_syncs),
+        'data': new_metas.to_json()
+      }
+    except (KeyError, RolledBackError) as e:
+      result = self._format_status_code_to_jsend(409, e.message)
+    except ValueError as e:
+      result = self._format_status_code_to_jsend(400, e.message)
+    except IndexError as e:
+      result = self._format_status_code_to_jsend(404, e.message)
+    return result
+
+  def delete_multi(self, uss_id, z, grids):
+    """Sets multiple GridCells metadata by removing the entry for the USS.
+
+    Reads data from zookeeper, including a snapshot token. The
+    snapshot token is used as a reference when writing to ensure
+    the data has not been updated between read and write.
+
+    Args:
+      uss_id: is the plain text identifier for the USS
+      z: zoom level in slippy tile format
+      grids: list of (x,y) tiles to delete
+    Returns:
+      JSend formatted response (https://labs.omniti.com/labs/jsend)
+    """
+    log.debug('Deleting multiple grid metadata for %s...', uss_id)
+    try:
+      if not uss_id:
+        raise ValueError('Invalid uss_id for deleting multi')
+      for x, y in grids:
+        if slippy_util.validate_slippy(z, x, y):
+          (content, metadata) = self._get_raw(z, x, y)
+          if metadata:
+            m = uss_metadata.USSMetadata(content)
+            m.remove_operator(uss_id)
+            # TODO(pelletierb): Automatically retry on delete
+            status = self._set_raw(z, x, y, m, metadata.version)
+        else:
+          raise ValueError('Invalid slippy grids for lookup')
+      result = self.get_multi(z, grids)
+    except ValueError as e:
+      result = self._format_status_code_to_jsend(400, e.message)
     return result
 
   ######################################################################
@@ -297,7 +408,8 @@ class USSMetadataManager(object):
       content: USS metadata
       metadata: straight from zookeeper
     """
-    path = GRID_PATH + '/'.join((str(z), str(x), str(y))) + USS_METADATA_FILE
+    path = '%s/%s/%s/%s/%s' % (GRID_PATH, str(z), str(x), str(y),
+                               USS_METADATA_FILE)
     log.debug('Getting metadata from zookeeper@%s...', path)
     self.zk.ensure_path(path)
     c, m = self.zk.get(path)
@@ -307,7 +419,7 @@ class USSMetadataManager(object):
       log.debug('Received raw metadata from zookeeper: %s', m)
     return c, m
 
-  def _set_raw(self, z, x, y, m, uss_id, sync_token):
+  def _set_raw(self, z, x, y, m, version):
     """Grabs the lock and updates the raw content for a GridCell in zookeeper.
 
     Args:
@@ -315,41 +427,118 @@ class USSMetadataManager(object):
       x: x tile number in slippy tile format
       y: y tile number in slippy tile format
       m: metadata object to write
-      uss_id: the plain text identifier for the USS
-      sync_token: the sync token received during get operation
+      version: the metadata version verified from the sync_token match
     Returns:
       200 for success, 409 for conflict, 408 for unable to get the lock
     """
-    status = 500
-    path = GRID_PATH + '/'.join((str(z), str(x), str(y))) + USS_METADATA_FILE
-    # TODO(hikevin): Remove Lock and use built in set with version
-    lock = self.zk.WriteLock(path, uss_id)
+    path = '%s/%s/%s/%s/%s' % (GRID_PATH, str(z), str(x), str(y),
+                               USS_METADATA_FILE)
     try:
-      log.debug('Getting metadata lock from zookeeper@%s...', path)
-      lock.acquire(timeout=LOCK_TIMEOUT)
-      (content, metadata) = self._get_raw(z, x, y)
-      del content
-      if str(metadata.last_modified_transaction_id) == str(sync_token):
-        log.debug('Setting metadata to %s...', str(m))
-        self.zk.set(path, json.dumps(m.to_json()))
-        status = 200
-      else:
-        log.error(
-            'Sync token from USS (%s) does not match token from zk (%s)...',
-            str(sync_token), str(metadata.last_modified_transaction_id))
-        status = 409
-      log.debug('Releasing the lock...')
-      lock.release()
-    except LockTimeout:
-      log.error('Unable to acquire the lock for %s...', path)
-      status = 408
+      log.debug('Setting metadata to %s...', str(m))
+      self.zk.set(path, json.dumps(m.to_json()), version)
+      status = 200
+    except BadVersionError:
+      log.error('Sync token updated before write for %s...', path)
+      status = 409
     return status
 
-  def _format_status_code_to_jsend(self, status):
+  def _get_multi_raw(self, z, grids):
+    """Gets the raw content and metadata for multiple GridCells from zookeeper.
+
+    Args:
+      z: zoom level in slippy tile format
+      grids: list of (x,y) tiles to retrieve
+    Returns:
+      content: Combined USS metadata
+      syncs: list of sync tokens in the same order as the grids
+    Raises:
+      IndexError: if it cannot find anything in zookeeper
+      ValueError: if the grid data is not in the right format
+    """
+    log.debug('Getting multiple grid metadata for %s...', str(grids))
+    metas = None
+    syncs = []
+    for x, y in grids:
+      if slippy_util.validate_slippy(z, x, y):
+        (content, metadata) = self._get_raw(z, x, y)
+        if metadata:
+          metas += uss_metadata.USSMetadata(content)
+          syncs.append(metadata.last_modified_transaction_id)
+        else:
+          raise IndexError('Unable to find metadata in platform')
+      else:
+        raise ValueError('Invalid slippy grids for lookup')
+    if len(syncs) == 0:
+      raise IndexError('Unable to find metadata in platform')
+    return metas, syncs
+
+  def _set_multi_raw(self, z, grids, sync_tokens, uss_id, ws_scope,
+    operation_format, operation_ws, earliest_operation, latest_operation):
+    """Grabs the lock and updates the raw content for multiple GridCells
+
+    Args:
+      z: zoom level in slippy tile format
+      grids: list of (x,y) tiles to retrieve
+      sync_tokens: list of the sync tokens received during get operation
+      uss_id: plain text identifier for the USS,
+      ws_scope: scope to use to obtain OAuth token,
+      operation_format: output format for operation ws (i.e. NASA, GUTMA),
+      operation_ws: submitting USS endpoint where all flights in
+        this cell can be retrieved from,
+      earliest_operation: lower bound of active or planned flight timestamp,
+        used for quick filtering conflicts.
+      latest_operation: upper bound of active or planned flight timestamp,
+        used for quick filtering conflicts.
+    Raises:
+      IndexError: if it cannot find anything in zookeeper
+      ValueError: if the grid data is not in the right format
+    """
+    log.debug('Setting multiple grid metadata for %s...', str(grids))
+    try:
+      contents = []
+      for i in range(len(grids)):
+        # First, get and update them all in memory, validate the sync_token
+        x = grids[i][0]
+        y = grids[i][1]
+        sync_token = sync_tokens[i]
+        path = '%s/%s/%s/%s/%s' % (GRID_PATH, str(z), str(x), str(y),
+                                   USS_METADATA_FILE)
+        (content, metadata) = self._get_raw(z, x, y)
+        if str(metadata.last_modified_transaction_id) == str(sync_token):
+          log.debug('Sync_token matches for %d, %d...', x, y)
+          m = uss_metadata.USSMetadata(content)
+          if not m.upsert_operator(uss_id, ws_scope, operation_format,
+                                   operation_ws, earliest_operation,
+                                   latest_operation, z, x, y):
+            raise ValueError('Failed to set operator content')
+          contents.append((path, m, metadata.version))
+        else:
+          log.error(
+            'Sync token from USS (%s) does not match token from zk (%s)...',
+            str(sync_token), str(metadata.last_modified_transaction_id))
+          raise KeyError('Composite sync_token has changed')
+      # Now, start a transaction to update them all
+      #  the version will catch any changes and roll back any attempted
+      #  updates to the grids
+      log.debug('Starting transaction to write all grids at once...')
+      t = self.zk.transaction()
+      for path, m, version in contents:
+        t.set_data(path, json.dumps(m.to_json()), version)
+      log.debug('Committing transaction...')
+      results = t.commit()
+      if isinstance(results[0], RolledBackError):
+        raise KeyError('Rolled back multi-grid transaction due to grid change')
+      log.debug('Committed transaction successfully.')
+    except (KeyError, ValueError, IndexError) as e:
+      log.error('Error caught in set_multi_raw %s.', e.message)
+      raise e
+
+  def _format_status_code_to_jsend(self, status, message=None):
     """Formats a response based on HTTP status code.
 
     Args:
       status: HTTP status code
+      message: optional message to override preset message for codes
     Returns:
       JSend formatted response (https://labs.omniti.com/labs/jsend)
     """
@@ -358,48 +547,52 @@ class USSMetadataManager(object):
       result = {'status': 'success', 'code': 204, 'message': 'Empty data set.'}
     elif status == 400:
       result = {
-          'status': 'fail',
-          'code': status,
-          'message': 'Parameters are not following the correct format.'
+        'status': 'fail',
+        'code': status,
+        'message': 'Parameters are not following the correct format.'
       }
     elif status == 404:
       result = {
-          'status': 'fail',
-          'code': status,
-          'message': 'Unable to pull metadata from lock system.'
+        'status': 'fail',
+        'code': status,
+        'message': 'Unable to pull metadata from lock system.'
       }
     elif status == 408:
       result = {
-          'status': 'fail',
-          'code': status,
-          'message': 'Timeout trying to get lock.'
+        'status': 'fail',
+        'code': status,
+        'message': 'Timeout trying to get lock.'
       }
     elif status == 409:
       result = {
-          'status':
-              'fail',
-          'code':
-              status,
-          'message':
-              'Content in metadata has been updated since provided sync token.'
+        'status':
+          'fail',
+        'code':
+          status,
+        'message':
+          'Content in metadata has been updated since provided sync token.'
       }
     elif status == 424:
       result = {
-          'status':
-              'fail',
-          'code':
-              status,
-          'message':
-              'Content in metadata is not following JSON format guidelines.'
+        'status':
+          'fail',
+        'code':
+          status,
+        'message':
+          'Content in metadata is not following JSON format guidelines.'
       }
     else:
       result = {
-          'status': 'fail',
-          'code': status,
-          'message': 'Unknown error code occurred.'
+        'status': 'fail',
+        'code': status,
+        'message': 'Unknown error code occurred.'
       }
+    if message:
+      result['message'] = message
     return result
 
-
-
-
+  @staticmethod
+  def _hash_sync_tokens(syncs):
+    """Hashes a list of sync tokens into a single, positive 64-bit int"""
+    log.debug('Hashing syncs: %s', str(sorted(syncs)))
+    return abs(hash(str(sorted(syncs))))

--- a/datanode/src/storage_interface_test.py
+++ b/datanode/src/storage_interface_test.py
@@ -21,6 +21,7 @@ from dateutil import parser
 from kazoo.handlers.threading import KazooTimeoutError
 
 import storage_interface
+#ZK_TEST_CONNECTION_STRING = '35.188.14.39:2181,35.224.180.72:2181'
 ZK_TEST_CONNECTION_STRING = 'localhost:2181'
 TESTID = 'storage-interface-test'
 PARALLEL_WORKERS = 10
@@ -32,6 +33,7 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
     # IMPORTANT: Puts us in a test data location
     self.mm = storage_interface.USSMetadataManager(
         ZK_TEST_CONNECTION_STRING, testgroupid=TESTID)
+    self.mm.set_verbose()
 
   def tearDown(self):
     # IMPORTANT: Clean out your test data when you are done
@@ -58,58 +60,52 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
           testgroupid=TESTID)
 
   def testGetCellNegativeCases(self):
-    self.assertEqual(self.mm.get(2, 1, 2**2)['status'], 'fail')
+    self.assertEqual('fail', self.mm.get(2, 1, 2**2)['status'])
     # x, y, z are ints
-    self.assertEqual(self.mm.get(1, '1a', 1)['status'], 'fail')
-    self.assertEqual(self.mm.get(1, 1, 'aa')['status'], 'fail')
-    self.assertEqual(self.mm.get(None, 1, 1)['status'], 'fail')
+    self.assertEqual('fail', self.mm.get(1, '1a', 1)['status'])
+    self.assertEqual('fail', self.mm.get(1, 1, 'aa')['status'])
+    self.assertEqual('fail', self.mm.get(None, 1, 1)['status'])
     # x and y tiles max are 2^zoom - 1
-    self.assertEqual(self.mm.get(1, 2, 1)['status'], 'fail')
-    self.assertEqual(self.mm.get(2, 5478118, 1)['status'], 'fail')
-    self.assertEqual(self.mm.get(2, 2**2, 1)['status'], 'fail')
-    self.assertEqual(self.mm.get(12, 2**12, 1)['status'], 'fail')
-    self.assertEqual(self.mm.get(1, 17, 1)['status'], 'fail')
-    self.assertEqual(self.mm.get(1, 1, 11)['status'], 'fail')
-    self.assertEqual(self.mm.get(9, 2**8, 2**11)['status'], 'fail')
+    self.assertEqual('fail', self.mm.get(1, 2, 1)['status'])
+    self.assertEqual('fail', self.mm.get(2, 5478118, 1)['status'])
+    self.assertEqual('fail', self.mm.get(2, 2**2, 1)['status'])
+    self.assertEqual('fail', self.mm.get(12, 2**12, 1)['status'])
+    self.assertEqual('fail', self.mm.get(1, 17, 1)['status'])
+    self.assertEqual('fail', self.mm.get(1, 1, 11)['status'])
+    self.assertEqual('fail', self.mm.get(9, 2**8, 2**11)['status'])
 
   def testGetCellPositiveEmptyCases(self):
-    # Make sure everything is clean
-    self.mm.delete_testdata()
     # simple 1,1,1
     r = self.mm.get(1, 1, 1)
-    self.assertEqual(r['status'], 'success')
+    self.assertEqual('success', r['status'])
     self.assertEqual(r['data']['version'], 0)
     # zero case
     r = self.mm.get(0, 0, 0)
-    self.assertEqual(r['status'], 'success')
+    self.assertEqual('success', r['status'])
     self.assertEqual(r['data']['version'], 0)
     r = self.mm.get(11, 0, 5)
-    self.assertEqual(r['status'], 'success')
+    self.assertEqual('success', r['status'])
     self.assertEqual(r['data']['version'], 0)
     # limit in the y direction
     r = self.mm.get(10, 1, 2**10 - 1)
-    self.assertEqual(r['status'], 'success')
+    self.assertEqual('success', r['status'])
     self.assertEqual(r['data']['version'], 0)
     # limit in the x direction
     r = self.mm.get(18, 2**18 - 1, 2**10 - 1)
-    self.assertEqual(r['status'], 'success')
+    self.assertEqual('success', r['status'])
     self.assertEqual(r['data']['version'], 0)
-    # Make sure everything is clean
-    self.mm.delete_testdata()
 
   def testPositiveGetSetDeleteCycle(self):
-    # Make sure everything is clean
-    self.mm.delete_testdata()
     # 2,1,1 get empty
     g = self.mm.get(2, 1, 1)
-    self.assertEqual(g['status'], 'success')
+    self.assertEqual('success', g['status'])
     self.assertEqual(g['data']['version'], 0)
     self.assertEqual(len(g['data']['operators']), 0)
     # simple set with basic values
     s = self.mm.set(2, 1, 1, g['sync_token'], 'uss', 'uss-scope', 'GUTMA',
                     'https://g.co/flight', '2018-01-01T00:00:00+00:00',
                     '2018-01-01T01:00:00+00:00')
-    self.assertEqual(s['status'], 'success')
+    self.assertEqual('success', s['status'])
     self.assertEqual(s['data']['version'], 1)
     self.assertEqual(len(s['data']['operators']), 1)
     o = s['data']['operators'][0]
@@ -123,30 +119,26 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
                      '2018-01-01T01:00:00+00:00')
     # simple delete
     d = self.mm.delete(2, 1, 1, 'uss')
-    self.assertEqual(d['status'], 'success')
+    self.assertEqual('success', d['status'])
     self.assertEqual(d['data']['version'], 2)
     self.assertEqual(len(d['data']['operators']), 0)
     # simple confirm get is empty
     g = self.mm.get(2, 1, 1)
-    self.assertEqual(g['status'], 'success')
+    self.assertEqual('success', g['status'])
     self.assertEqual(g['data']['version'], 2)
     self.assertEqual(len(g['data']['operators']), 0)
-    # Make sure everything is clean
-    self.mm.delete_testdata()
 
   def testSetCellWithOutdatedsync_token(self):
-    # Make sure everything is clean
-    self.mm.delete_testdata()
     # 3,1,1 get empty
     g = self.mm.get(3, 1, 1)
-    self.assertEqual(g['status'], 'success')
+    self.assertEqual('success', g['status'])
     self.assertEqual(g['data']['version'], 0)
     self.assertEqual(len(g['data']['operators']), 0)
     # simple set with basic values
     s = self.mm.set(3, 1, 1, g['sync_token'], 'uss1', 'uss1-scope', 'GUTMA',
                     'https://g.co/flight', '2018-01-01T00:00:00+00:00',
                     '2018-01-01T01:00:00+00:00')
-    self.assertEqual(s['status'], 'success')
+    self.assertEqual('success', s['status'])
     self.assertEqual(s['data']['version'], 1)
     self.assertEqual(len(s['data']['operators']), 1)
     # now try to do a set with the original sync token
@@ -156,18 +148,14 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
     self.assertEqual(s['status'], 'fail')
     # confirm version is still the first write
     g = self.mm.get(3, 1, 1)
-    self.assertEqual(g['status'], 'success')
+    self.assertEqual('success', g['status'])
     self.assertEqual(g['data']['version'], 1)
     self.assertEqual(len(g['data']['operators']), 1)
-    # Make sure everything is clean
-    self.mm.delete_testdata()
 
   def testSetCellsInParallelWithSamesync_token(self):
-    # Make sure everything is clean
-    self.mm.delete_testdata()
     # 4,1,1 get empty
     g = self.mm.get(4, 1, 1)
-    self.assertEqual(g['status'], 'success')
+    self.assertEqual('success', g['status'])
     self.assertEqual(g['data']['version'], 0)
     self.assertEqual(len(g['data']['operators']), 0)
     threads = []
@@ -182,11 +170,9 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
     t.join()
     # confirm there is only one update
     g = self.mm.get(4, 1, 1)
-    self.assertEqual(g['status'], 'success')
+    self.assertEqual('success', g['status'])
     self.assertEqual(g['data']['version'], 1)
     self.assertEqual(len(g['data']['operators']), 1)
-    # Make sure everything is clean
-    self.mm.delete_testdata()
 
   def SetCellWorker(self, num, sync_token):
     self.mm.set(4, 1, 1, sync_token, 'uss' + str(num), 'uss-scope' + str(num),
@@ -195,8 +181,6 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
     return
 
   def testSetCellsWithInvalidTimestamps(self):
-    # Make sure everything is clean
-    self.mm.delete_testdata()
     # 5,1,1 get empty
     s = self.mm.get(5, 1, 1)
     token = s['sync_token']
@@ -207,13 +191,8 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
       s = self.mm.set(5, 1, 1, token, 'uss', 'uss-scope', 'GUTMA',
                       'https://g.co/flight', test[0], test[1])
       self.assertEqual(s['status'], 'fail')
-    # Make sure everything is clean
-    self.mm.delete_testdata()
-    return
 
   def testSetCellsWithValidTimestamps(self):
-    # Make sure everything is clean
-    self.mm.delete_testdata()
     # 5,1,1 get empty
     s = self.mm.get(5, 1, 1)
     token = s['sync_token']
@@ -226,7 +205,7 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
       s = self.mm.set(5, 1, 1, token, 'uss', 'uss-scope', 'GUTMA',
                       'https://g.co/flight', test[0], test[1])
       token = s['sync_token']
-      self.assertEqual(s['status'], 'success')
+      self.assertEqual('success', s['status'])
       o = s['data']['operators'][0]
       # Fix up the test cases to compare, this isn't what is sent to the api
       mintest = test[0]
@@ -243,9 +222,142 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
       self.assertAlmostEqual(
         0, (parser.parse(maxtest) -
             parser.parse(o['maximum_operation_timestamp'])).total_seconds(), 0)
-    # Make sure everything is clean
-    self.mm.delete_testdata()
-    return
+
+  def testGetCellMultipleCellCases(self):
+    r1 = self.mm.get_multi(6, [(0, 0), (0, 1), (1, 1)])
+    self.assertEqual('success', r1['status'])
+    self.assertEqual(0, r1['data']['version'])
+    # now do a write to a single cell
+    g = self.mm.get(6, 0, 1)
+    s = self.mm.set(6, 0, 1, g['sync_token'], 'uss1', 'uss1-scope', 'GUTMA',
+                    'https://g.co/flight/0/1', '2018-01-01T00:00:00+00:00',
+                    '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    # confirm the sync_token has changed on multi
+    r2 = self.mm.get_multi(6, [(0, 0), (0, 1), (1, 1)])
+    self.assertNotEqual(r1['sync_token'], r2['sync_token'])
+    # add a few more writes
+    g = self.mm.get(6, 1, 1)
+    s = self.mm.set(6, 1, 1, g['sync_token'], 'uss1', 'uss1-scope', 'GUTMA',
+                    'https://g.co/flight/1/1', '2018-01-01T00:00:00+00:00',
+                    '2018-01-01T01:00:00+00:00')
+    g = self.mm.get(6, 1, 1)
+    s = self.mm.set(6, 1, 1, g['sync_token'], 'uss2', 'uss2-scope', 'GUTMA',
+                    'https://g2.co/uss2/1/1', '2018-01-01T00:00:00+00:00',
+                    '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    # Now get them all and confirm you have the right amount
+    r3 = self.mm.get_multi(6, [(0, 0), (0, 1), (1, 1)])
+    self.assertEqual('success', r3['status'])
+    self.assertNotEqual(r1['sync_token'], r3['sync_token'])
+    self.assertNotEqual(r2['sync_token'], r3['sync_token'])
+    self.assertEqual(2, r3['data']['version'])
+    self.assertEqual(3, len(r3['data']['operators']))
+
+  def testDeleteCellMultipleCellCases(self):
+    grids = [(0, 0), (0, 1), (1, 1)]
+    r1 = self.mm.get_multi(7, grids)
+    self.assertEqual('success', r1['status'])
+    self.assertEqual(0, r1['data']['version'])
+    g = self.mm.get(7, 0, 1)
+    s = self.mm.set(7, 0, 1, g['sync_token'], 'uss1', 'uss1-scope', 'GUTMA',
+                    'https://g.co/flight/0/1', '2018-01-01T00:00:00+00:00',
+                    '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    # add a few more writes
+    g = self.mm.get(7, 1, 1)
+    s = self.mm.set(7, 1, 1, g['sync_token'], 'uss1', 'uss1-scope', 'GUTMA',
+                    'https://g.co/flight/1/1', '2018-01-01T00:00:00+00:00',
+                    '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    g = self.mm.get(7, 1, 1)
+    s = self.mm.set(7, 1, 1, g['sync_token'], 'uss2', 'uss2-scope', 'GUTMA',
+                    'https://g2.co/uss2/1/1', '2018-01-01T00:00:00+00:00',
+                    '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    # Now try deleting uss1, which would delete from two different cells
+    r2 = self.mm.delete_multi('uss1', 7, grids)
+    self.assertEqual('success', r2['status'])
+    self.assertNotEqual(r1['sync_token'], r2['sync_token'])
+    self.assertEqual(3, r2['data']['version'])
+    self.assertEqual(1, len(r2['data']['operators']))
+
+  def testInvalidMultipleCellCases(self):
+    r = self.mm.get_multi(6, [])
+    self.assertEqual('fail', r['status'])
+    r = self.mm.get_multi(6, '0,0,1,1,0,1')
+    self.assertEqual('fail', r['status'])
+    r = self.mm.delete_multi(None, 6, [(0, 0), (0, 1), (1, 1)])
+    self.assertEqual('fail', r['status'])
+    r = self.mm.delete_multi('uss', 21, [(0, 0), (0, 1), (1, 1)])
+    self.assertEqual('fail', r['status'])
+
+  def testSetMultipleCellCases(self):
+    grids = [(0, 0), (0, 1), (1, 1)]
+    g = self.mm.get_multi(8, grids)
+    self.assertEqual('success', g['status'])
+    self.assertEqual(0, g['data']['version'])
+    # now do a write to multiple cells
+    s = self.mm.set_multi(8, grids, g['sync_token'], 'uss1', 'uss1-scope',
+                          'GUTMA', 'https://g.co/flight/{z}/{x}/{y}',
+                          '2018-01-01T00:00:00+00:00',
+                          '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    self.assertEqual(1, s['data']['version'])
+
+  def testFullCycleMultipleCellCases(self):
+    grids = [(0, 0), (0, 1), (1, 1)]
+    g = self.mm.get_multi(9, grids)
+    self.assertEqual('success', g['status'])
+    self.assertEqual(0, g['data']['version'])
+    # now do a write to multiple cells
+    s = self.mm.set_multi(9, grids, g['sync_token'], 'uss1', 'uss1-scope',
+                          'GUTMA', 'https://g1.co/flight/{z}/{x}/{y}',
+                          '2018-01-01T00:00:00+00:00',
+                          '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    self.assertNotEqual(g['sync_token'], s['sync_token'])
+    self.assertEqual(1, s['data']['version'])
+    self.assertEqual(3, len(s['data']['operators']))
+    # Do a write to two other cells
+    grids = [(0, 0), (1, 1)]
+    g = self.mm.get_multi(9, grids)
+    self.assertEqual('success', g['status'])
+    self.assertEqual(1, g['data']['version'])
+    s = self.mm.set_multi(9, grids, g['sync_token'], 'uss2', 'uss2-scope',
+                          'GUTMA', 'https://g2.co/flight/{z}/{x}/{y}',
+                          '2018-01-01T00:00:00+00:00',
+                          '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    self.assertNotEqual(g['sync_token'], s['sync_token'])
+    self.assertEqual(2, s['data']['version'])
+    self.assertEqual(4, len(s['data']['operators']))
+    grids = [(0, 0), (0, 1), (1, 1)]
+    s = self.mm.get_multi(9, grids)
+    self.assertEqual('success', s['status'])
+    self.assertEqual(2, s['data']['version'])
+    self.assertEqual(5, len(s['data']['operators']))
+    multi_token = s['sync_token']
+    # Now write to another cell singly and then update using old token
+    g = self.mm.get(9, 0, 1)
+    s = self.mm.set(9, 0, 1, g['sync_token'], 'uss3', 'uss3-scope', 'GUTMA',
+                    'https://g3.co/f/{z}/{x}/{y}', '2018-01-01T00:00:00+00:00',
+                    '2018-01-01T01:00:00+00:00')
+    self.assertEqual('success', s['status'])
+    s = self.mm.set_multi(9, grids, multi_token, 'ussXX', 'ussXX-scope',
+                          'GUTMA', 'https://gXX.co/flight/{z}/{x}/{y}',
+                          '2018-01-01T00:00:00+00:00',
+                          '2018-01-01T01:00:00+00:00')
+    self.assertEqual('fail', s['status'])
+    grids = [(0, 0), (0, 1), (0, 2),
+             (1, 0), (1, 1), (1, 2),
+             (2, 0), (2, 1), (2, 2),
+             (3, 0), (3, 1), (3, 2)]
+    g = self.mm.get_multi(9, grids)
+    s = self.mm.set_multi(9, grids, g['sync_token'], 'uss4', 'uss4-scope',
+                          'GUTMA', 'https://g4.co/flight/{z}/{x}/{y}',
+                          '2018-01-01T00:00:00+00:00',
+                          '2018-01-01T01:00:00+00:00')
 
 
 if __name__ == '__main__':

--- a/datanode/src/storage_interface_test.py
+++ b/datanode/src/storage_interface_test.py
@@ -21,6 +21,8 @@ from dateutil import parser
 from kazoo.handlers.threading import KazooTimeoutError
 
 import storage_interface
+import uss_metadata
+
 ZK_TEST_CONNECTION_STRING = 'localhost:2181'
 TESTID = 'storage-interface-test'
 PARALLEL_WORKERS = 10
@@ -365,6 +367,26 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
                           'GUTMA', 'https://g4.co/flight/{z}/{x}/{y}',
                           '2018-01-01T00:00:00+00:00',
                           '2018-01-01T01:00:00+00:00')
+
+  def testUSSmetadatAddition(self):
+    a = uss_metadata.USSMetadata()
+    a.upsert_operator('uss-a', 'scope-a', 'NASA', 'http://a.com/uss',
+                      '2018-01-01', '2018-01-02', 10, 1, 1)
+    b1 = uss_metadata.USSMetadata()
+    b1.upsert_operator('uss-b', 'scope-b', 'NASA', 'http://b.com/uss',
+                      '2018-01-01', '2018-01-02', 10, 1, 1)
+    b2 = uss_metadata.USSMetadata()
+    b2.upsert_operator('uss-b', 'scope-b', 'NASA', 'http://b.com/uss',
+                       '2018-01-01', '2018-01-02', 10, 1, 2)
+    usss = a + b1 + b2
+    self.assertEqual(3, len(usss.operators))
+    with self.assertRaises(ValueError):
+      usss = a + a
+    ax = uss_metadata.USSMetadata()
+    ax.upsert_operator('uss-a', 'scope-ax', 'NASA', 'http://ax.com/uss',
+                      '2018-01-03', '2018-01-04', 10, 1, 1)
+    with self.assertRaises(ValueError):
+      usss = a + ax
 
 
 if __name__ == '__main__':

--- a/datanode/src/storage_interface_test.py
+++ b/datanode/src/storage_interface_test.py
@@ -21,7 +21,6 @@ from dateutil import parser
 from kazoo.handlers.threading import KazooTimeoutError
 
 import storage_interface
-#ZK_TEST_CONNECTION_STRING = '35.188.14.39:2181,35.224.180.72:2181'
 ZK_TEST_CONNECTION_STRING = 'localhost:2181'
 TESTID = 'storage-interface-test'
 PARALLEL_WORKERS = 10
@@ -293,7 +292,10 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
     self.assertEqual('fail', r['status'])
 
   def testSetMultipleCellCases(self):
-    grids = [(0, 0), (0, 1), (1, 1)]
+    grids = [(0, 0), (0, 1), (0, 2),
+             (1, 0), (1, 1), (1, 2),
+             (2, 0), (2, 1), (2, 2),
+             (3, 0), (3, 1), (3, 2)]
     g = self.mm.get_multi(8, grids)
     self.assertEqual('success', g['status'])
     self.assertEqual(0, g['data']['version'])
@@ -304,6 +306,11 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
                           '2018-01-01T01:00:00+00:00')
     self.assertEqual('success', s['status'])
     self.assertEqual(1, s['data']['version'])
+    self.assertEqual(len(grids), len(s['data']['operators']))
+    g = self.mm.get_multi(8, grids)
+    self.assertEqual('success', s['status'])
+    self.assertEqual(1, s['data']['version'])
+    self.assertEqual(len(grids), len(s['data']['operators']))
 
   def testFullCycleMultipleCellCases(self):
     grids = [(0, 0), (0, 1), (1, 1)]
@@ -318,7 +325,7 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
     self.assertEqual('success', s['status'])
     self.assertNotEqual(g['sync_token'], s['sync_token'])
     self.assertEqual(1, s['data']['version'])
-    self.assertEqual(3, len(s['data']['operators']))
+    self.assertEqual(len(grids), len(s['data']['operators']))
     # Do a write to two other cells
     grids = [(0, 0), (1, 1)]
     g = self.mm.get_multi(9, grids)

--- a/datanode/src/uss_metadata.py
+++ b/datanode/src/uss_metadata.py
@@ -42,7 +42,7 @@ log = logging.getLogger('InterUSS_DataNode_InformationInterface')
 
 
 class USSMetadata(object):
-  """Data structure for the metadata stored for USS entries in a GridCell.
+  """Data structure for the USS metadata stored for one or more GridCells.
 
   Format: {version: <version>, timestamp: <last_updated>, operators:
     [{uss: <ussid>, scope: <used_for_obtaining_oauth_tokens>,
@@ -50,7 +50,10 @@ class USSMetadata(object):
     operation_endpoint: <endpoint_to_retrieve_operations_in_this_grid>,
     operation_format: <output_format_of_uas_operations>,
     minimum_operation_timestamp: <lowest_start_time_of_operations_in_this_cell>,
-    maximum_operation_timestamp: <highest_end_time_of_operations_in_this_cell>
+    maximum_operation_timestamp: <highest_end_time_of_operations_in_this_cell>,
+    zoom: <slippy_zoom_level_for_the_gridcell>,
+    x: <slippy_x_level_for_the_gridcell>,
+    y: <slippy_y_level_for_the_gridcell>,
     },
       ...other USSs as appropriate... ]
   }
@@ -82,6 +85,13 @@ class USSMetadata(object):
         combined.timestamp = other.timestamp
       for operator in other.operators:
         combined.operators.append(operator)
+    keys = []
+    for o in combined.operators:
+      key = (o['uss'], o['zoom'], o['x'], o['y'])
+      if key in keys:
+        raise ValueError('Duplicate USS ID, zoom, x, y found during add')
+      else:
+        keys.append(key)
     return combined
 
   def __radd__(self, other):
@@ -98,7 +108,7 @@ class USSMetadata(object):
     }
 
   def upsert_operator(self, uss_id, ws_scope, operation_format, operation_ws,
-    earliest, latest, zoom=None, x=None, y=None):
+    earliest, latest, zoom, x, y):
     """Inserts or updates an operation, with uss_id as the key.
 
     Args:
@@ -142,22 +152,9 @@ class USSMetadata(object):
       'maximum_operation_timestamp': self.format_ts(latest_operation)
     }
     self.operators.append(operator)
-    self.update_grid_location(zoom, x, y)
+    self._update_grid_location(zoom, x, y)
     self.timestamp = self.format_ts()
     return True
-
-  def update_grid_location(self, z, x, y):
-    """Updates the z, x, y fields and any variables in the endpoints"""
-    if not (z is None or x is None or y is None):
-      for operator in self.operators:
-        operator['zoom'] = z
-        operator['x'] = x
-        operator['y'] = y
-        e = operator['operation_endpoint']
-        e = e.replace('{zoom}', str(z)).replace('{z}', str(z))
-        e = e.replace('{x}', str(x))
-        e = e.replace('{y}', str(y))
-        operator['operation_endpoint'] = e
 
   def remove_operator(self, uss_id):
     self.version += 1
@@ -171,3 +168,18 @@ class USSMetadata(object):
     r = datetime.datetime.now(pytz.utc) if timestamp is None else timestamp
     r = r.astimezone(pytz.utc)
     return r.isoformat()
+
+  def _update_grid_location(self, z, x, y):
+    """Updates the z, x, y fields and any variables in the endpoints"""
+    if z is None or x is None or y is None:
+      raise ValueError('Slippy values not set for grid location')
+    else:
+      for operator in self.operators:
+        operator['zoom'] = z
+        operator['x'] = x
+        operator['y'] = y
+        e = operator['operation_endpoint']
+        e = e.replace('{zoom}', str(z)).replace('{z}', str(z))
+        e = e.replace('{x}', str(x))
+        e = e.replace('{y}', str(y))
+        operator['operation_endpoint'] = e


### PR DESCRIPTION
Underlying changes for supporting multiple grids, this pull request has a few changes:
- Change zookeeper interface to use version instead of locks for writing (sync_token still validated)
- Change test cases to be more readable
- Add zoom, x, and y in the metadata response (in each operator, fixes #32 )
- get, set, and delete operations for multiple grids using zookeeper transaction/commit functions and zookeeper version numbers to quickly update and rollback if needed
- Started progress on using proper error handling in storage_interface.py

Only API changes are on Swaggerhub (zoom, x, y in operator response). Still internally version 1.0.2
https://app.swaggerhub.com/apis/InterUSS_Platform/data_node_api/1.1.0#/

Next change will be the storage API to support multiple grids using a new endpoint /GridCellsMetaData.