### PR TITLE
API Changes to support multi-grid GET/PUT/DEL

### DIFF
--- a/datanode/docker/Dockerfile_storageapi
+++ b/datanode/docker/Dockerfile_storageapi
@@ -38,7 +38,7 @@ FROM python:2
 
 WORKDIR /usr/src/app
 
-RUN pip install --no-cache-dir python-dateutil kazoo flask PyJWT djangorestframework cryptography pytz gunicorn
+RUN pip install --no-cache-dir python-dateutil kazoo flask PyJWT djangorestframework cryptography pytz gunicorn shapely
 
 COPY . .
 

--- a/datanode/docker/README.md
+++ b/datanode/docker/README.md
@@ -36,7 +36,7 @@ By layering this docker-compose configuration on top of docker-compose.yaml,
 users may provide their own SSL certificates. This is the intended usage in
 production.
 
-## Usage
+## Test Usage
 
 ### Stand-alone test node
 
@@ -70,7 +70,7 @@ export INTERUSS_PUBLIC_KEY=[paste public key here]
 docker-compose -p datanode up
 ```
 
-## SSL
+### SSL
 
 By default, the data node docker-compose configuration will serve HTTPS
 requests on port 8121 using a test self-signed certificate included in this
@@ -99,9 +99,9 @@ export ZOO_MY_ID=[your InterUSS Platform network Zookeeper ID]
 export ZOO_SERVERS=[InterUSS Platform server network; ex: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888, make sure your server is 0.0.0.0]
 export INTERUSS_PUBLIC_KEY=[paste public key here]
 
-docker run --name="tcl4-zookeeper" --restart always -p 2888:2888 -p 3888:3888 --expose 2181 -e ZOO_MY_ID="${ZOO_MY_ID}" -e ZOO_SERVERS="${ZOO_SERVERS}" -d zookeeper
+docker run --name="datanode-zookeeper" --restart always -p 2888:2888 -p 3888:3888 --expose 2181 -e ZOO_MY_ID="${ZOO_MY_ID}" -e ZOO_SERVERS="${ZOO_SERVERS}" -d zookeeper
 
-docker run --name="tcl4-storage_api" --link="tcl4-zookeeper" --restart always --expose 5000 -e INTERUSS_API_PORT=5000 -e INTERUSS_PUBLIC_KEY="${INTERUSS_PUBLIC_KEY}" -e INTERUSS_CONNECTIONSTRING="tcl4-zookeeper:2181" -e INTERUSS_VERBOSE=true -d interussplatform/storage_api:tcl4
+docker run --name="datanode-storage_api" --link="tcl4-zookeeper" --restart always --expose 5000 -e INTERUSS_API_PORT=5000 -e INTERUSS_PUBLIC_KEY="${INTERUSS_PUBLIC_KEY}" -e INTERUSS_CONNECTIONSTRING="datanode-zookeeper:2181" -e INTERUSS_VERBOSE=true -d interussplatform/storage_api:tcl4
 
-docker run --name="tcl4-reverse_proxy" --link="tcl4-storage_api" --restart always -p 8120:8120 -p 8121:8121 -e INTERUSS_API_PORT_HTTP=${INTERUSS_API_PORT_HTTP:-8120} -e INTERUSS_API_PORT_HTTPS=${INTERUSS_API_PORT_HTTPS:-8121} -e STORAGE_API_SERVER="tcl4-storage_api" -e STORAGE_API_PORT=5000 -d interussplatform/reverse_proxy
+docker run --name="datanode-reverse_proxy" --link="tcl4-storage_api" --restart always -p 8120:8120 -p 8121:8121 -e INTERUSS_API_PORT_HTTP=${INTERUSS_API_PORT_HTTP:-8120} -e INTERUSS_API_PORT_HTTPS=${INTERUSS_API_PORT_HTTPS:-8121} -e STORAGE_API_SERVER="datanode-storage_api" -e STORAGE_API_PORT=5000 -d interussplatform/reverse_proxy
 ```

--- a/datanode/docker/docker-compose.yaml
+++ b/datanode/docker/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
       - ZOO_SERVERS=${ZOO_SERVERS:-server.1=0.0.0.0:2888:3888}
 
   storage_api:
-    image: interussplatform/storage_api
+    image: interussplatform/storage_api:tcl4
     expose:
       - 5000
     environment:

--- a/datanode/src/slippy_util.py
+++ b/datanode/src/slippy_util.py
@@ -41,6 +41,8 @@ from shapely.geometry import Polygon
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 log = logging.getLogger('InterUSS_DataNode_SlippyUtil')
 
+TILE_LIMIT = 50  # Number of tiles to allow for multi get/put/del
+
 
 def validate_slippy(z, x, y, raise_error=False):
   """Validates slippy tile ranges.
@@ -258,6 +260,9 @@ def _calculate_tiles_from_bounding_box(zoom, bbox):
     x, y = convert_point_to_tile(zoom, lat, lon)
     if (x, y) not in result:
       result.append((x, y))
+      if len(result) > TILE_LIMIT:
+        raise OverflowError('Limit of %d tiles impacted exceeded'
+                            % (TILE_LIMIT))
     last = (lat, lon)
   if not result:
     raise ValueError('No tiles found for path coordinates')

--- a/datanode/src/slippy_util.py
+++ b/datanode/src/slippy_util.py
@@ -187,29 +187,6 @@ def convert_polygon_to_tiles(zoom, points):
   return _convert_shape_to_tiles(zoom, points, is_poly=True)
 
 
-def convert_points_to_geojson(points, headers=True, name='slippy-out'):
-  """ Converts a set of lat/lon points into a path in geojson format."""
-  result = ''
-  if headers:
-    result += """{
-      "type": "FeatureCollection",
-      "features": ["""
-  result += """{
-      "type": "Feature",
-      "properties": {"name" : "%s" },
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [ [ """ % name
-  for lat, lon in points:
-    result += "[ %.5f, %.5f ]," % (lon, lat)
-  result = result[:-1] + """] ]
-        }
-      }"""
-  if headers:
-    result +=' ] }'
-  return result
-
-
 ######################################################################
 ################       INTERNAL FUNCTIONS    #########################
 ######################################################################

--- a/datanode/src/slippy_util_test.py
+++ b/datanode/src/slippy_util_test.py
@@ -74,25 +74,25 @@ class InterUSSSlippyUtilitiesTestCase(unittest.TestCase):
 
   def testInvalidPointConversions(self):
     with self.assertRaises(ValueError):
-      self.assertIsNone(slippy_util.convert_point_to_tile(-1, 0, 0))
+      slippy_util.convert_point_to_tile(-1, 0, 0)
     with self.assertRaises(ValueError):
-      self.assertIsNone(slippy_util.convert_point_to_tile(21, 0, 0))
+      slippy_util.convert_point_to_tile(21, 0, 0)
     with self.assertRaises(ValueError):
-      self.assertIsNone(slippy_util.convert_point_to_tile(1, 91, 10))
+      slippy_util.convert_point_to_tile(1, 91, 10)
     with self.assertRaises(ValueError):
-      self.assertIsNone(slippy_util.convert_point_to_tile(1, 10, 191))
+      slippy_util.convert_point_to_tile(1, 10, 191)
     with self.assertRaises(TypeError):
-      self.assertIsNone(slippy_util.convert_point_to_tile(1, 10, None))
+      slippy_util.convert_point_to_tile(1, 10, None)
     with self.assertRaises(ValueError):
-      self.assertEqual(1, len(slippy_util.convert_path_to_tiles(0, [(0, 0)])))
+      slippy_util.convert_path_to_tiles(0, [(0, 0)])
+    with self.assertRaises(OverflowError):
+      slippy_util.convert_path_to_tiles(15, [(0, 0), (1, 1.5)])
 
   def testValidPathConversions(self):
     self.assertEqual(1,
                      len(slippy_util.convert_path_to_tiles(0, [(0, 0), (1, 1.5)])))
     self.assertEqual(2,
                      len(slippy_util.convert_path_to_tiles(5, [(0, 0), (1, 1.5)])))
-    self.assertEqual(229,
-                     len(slippy_util.convert_path_to_tiles(15, [(0, 0), (1, 1.5)])))
     # One segment should be the same as two segments that overlapp
     self.assertEqual(len(slippy_util.convert_path_to_tiles(10, [(0, 0), (1, 1.5)])),
                      len(slippy_util.convert_path_to_tiles(10, [(0, 0), (1, 1.5),
@@ -121,6 +121,11 @@ class InterUSSSlippyUtilitiesTestCase(unittest.TestCase):
       slippy_util.convert_path_to_tiles(0, [])
     with self.assertRaises(TypeError):
       slippy_util.convert_path_to_tiles(0, [(0), (1)])
+    # test a lot of tiles calculation
+    with self.assertRaises(OverflowError):
+      slippy_util.convert_polygon_to_tiles(15, [(47.5, -103), (47.5, -101.8),
+                                                (48, -101.8), (48, -103),
+                                                (47.5, -103)])
 
   def testValidPolygonConversions(self):
     self.assertEqual(1, len(
@@ -137,11 +142,6 @@ class InterUSSSlippyUtilitiesTestCase(unittest.TestCase):
       slippy_util.convert_polygon_to_tiles(9, [(47.5, -103), (47.5, -101.8),
                                                (48, -101.8), (48, -103),
                                                (47.5, -103)])))
-    # test the duration of a lot of tiles calculation
-    self.assertEqual(7590, len(
-      slippy_util.convert_polygon_to_tiles(15, [(47.5, -103), (47.5, -101.8),
-                                                (48, -101.8), (48, -103),
-                                                (47.5, -103)])))
 
   def testInvalidPolygonConversions(self):
     with self.assertRaises(TypeError):

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -512,7 +512,7 @@ def _DeleteGridCellsMetaData(zoom, tiles, uss_id):
   log.info('Grid cells metadata delete instantiated for %s, %sz, %s...',
            uss_id, zoom, str(tiles))
   if uss_id:
-    result = wrapper.delete_multi(uss_id, zoom, tiles)
+    result = wrapper.delete_multi(zoom, tiles, uss_id)
   else:
     result = {
       'status':

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -125,7 +125,7 @@ def ConvertCoordinatesToSlippy(zoom):
   log.info('Convert coordinates to slippy instantiated for %sz...', zoom)
   try:
     zoom = int(zoom)
-    tiles = _ConvertCSVtoTiles(zoom)
+    tiles = _ConvertRequestToTiles(zoom)
     result = []
     for x, y in tiles:
       link = 'http://tile.openstreetmap.org/%d/%d/%d.png' % (zoom, x, y)
@@ -156,7 +156,8 @@ def GridCellMetaDataHandler(zoom, x, y):
     x: x tile number in slippy tile format
     y: y tile number in slippy tile format
     OAuth access_token as part of the header
-    Plus posted webargs as needed for PUT/POST and DELETE methods (see below)
+    Plus posted webargs as needed for PUT/POST and DELETE methods
+      (see internal functions Get/Put/Delete metadata below)
   Returns:
     200 with token and metadata in JSON format,
     or the nominal 4xx error codes as necessary.
@@ -193,7 +194,9 @@ def GridCellsMetaDataHandler(zoom):
     Plus posted webargs:
       coords: csv of lon,lat,long,lat,etc.
       coord_type: (optional) type of coords - point (default), path, polygon
-      and additional as needed for PUT/POST and DELETE methods (see below)
+       and additional as needed for PUT/POST and DELETE methods
+       (see internal functions Get/Put/Delete metadata below)
+
   Returns:
     200 with token and metadata in JSON format,
     or the nominal 4xx error codes as necessary.
@@ -202,7 +205,7 @@ def GridCellsMetaDataHandler(zoom):
   result = {}
   try:
     zoom = int(zoom)
-    tiles = _ConvertCSVtoTiles(zoom)
+    tiles = _ConvertRequestToTiles(zoom)
     if len(tiles) > slippy_util.TILE_LIMIT:
       raise OverflowError('Limit of %d tiles impacted exceeded (%d)'
                           % (slippy_util.TILE_LIMIT, len(tiles)))
@@ -523,7 +526,7 @@ def _DeleteGridCellsMetaData(zoom, tiles, uss_id):
   return result
 
 
-def _ConvertCSVtoTiles(zoom):
+def _ConvertRequestToTiles(zoom):
   """Converts an CSV of coords into slippy tile format at the specified zoom
       and the specified coordinate type (path, polygon, point) """
   tiles = []

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -189,8 +189,6 @@ def GridCellsMetaDataHandler(zoom):
 
   Args:
     zoom: zoom level in slippy tile format
-    x: x tile number in slippy tile format
-    y: y tile number in slippy tile format
     OAuth access_token as part of the header
     Plus posted webargs:
       coords: csv of lon,lat,long,lat,etc.

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -71,9 +71,11 @@ import slippy_util
 # VERSION = '1.0.2.001'  # Refactored to run with gunicorn
 # VERSION = '1.0.2.002'  # Standardize OAuth Authorization header, docker fix
 # VERSION = '1.0.2.003'  # slippy utility updates to support point/path/polygon
-VERSION = '1.0.2.004'  # slippy non-breaking api changes to support path/polygon
+# VERSION = '1.0.2.004'  # slippy non-breaking api changes to support path/polygon
+VERSION = '1.1.0.005'  # api changes to support multi-grid GET/PUT/DEL
 
 TESTID = None
+TILE_LIMIT = 25  # Number of tiles to allow for multi get/put/del
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 log = logging.getLogger('InterUSS_DataNode_StorageAPI')
@@ -114,7 +116,9 @@ def ConvertCoordinatesToSlippy(zoom):
   """Converts an CSV of coords to slippy tile format at the specified zoom.
   Args:
     zoom: zoom level to use for encapsulating the tiles
-    Plus posted webarg coords: csv of lon,lat,long,lat,etc.
+    Plus posted webargs
+     coords: csv of lon,lat,long,lat,etc.
+     coord_type: (optional) type of coords - point (default), path, polygon
   Returns:
     200 with tiles array in JSON format,
     or the nominal 4xx error codes as necessary.
@@ -122,23 +126,7 @@ def ConvertCoordinatesToSlippy(zoom):
   log.info('Convert coordinates to slippy instantiated for %sz...', zoom)
   try:
     zoom = int(zoom)
-    tiles = []
-    coords = _GetRequestParameter('coords', '')
-    coord_type = _GetRequestParameter('coord_type', 'point')
-    log.debug('Retrieved coords from web params and split to %s...', coords)
-    coordinates = slippy_util.convert_csv_to_coordinates(coords)
-    if not coordinates:
-      log.error('Invalid coords %s, must be a CSV of lat,lon...', coords)
-      raise ValueError('Invalid coords, must be a CSV of lat,lon,lat,lon...')
-    if coord_type == 'point':
-      for c in coordinates:
-        tiles.append((slippy_util.convert_point_to_tile(zoom, c[0], c[1])))
-    elif coord_type == 'path':
-      tiles = slippy_util.convert_path_to_tiles(zoom, coordinates)
-    elif coord_type == 'polygon':
-      tiles = slippy_util.convert_polygon_to_tiles(zoom, coordinates)
-    else:
-      raise ValueError('Invalid coord_type, must be point/path/polygon')
+    tiles = _ConvertCSVtoTiles(zoom)
     result = []
     for x, y in tiles:
       link = 'http://tile.openstreetmap.org/%d/%d/%d.png' % (zoom, x, y)
@@ -183,13 +171,54 @@ def GridCellMetaDataHandler(zoom, x, y):
   except ValueError:
     abort(status.HTTP_400_BAD_REQUEST,
           'Invalid parameters for slippy tile coordinates, must be integers.')
-  # Check the request method
   if request.method == 'GET':
     result = _GetGridCellMetaData(zoom, x, y)
   elif request.method in ('PUT', 'POST'):
     result = _PutGridCellMetaData(zoom, x, y, uss_id)
   elif request.method == 'DELETE':
     result = _DeleteGridCellMetaData(zoom, x, y, uss_id)
+  else:
+    abort(status.HTTP_405_METHOD_NOT_ALLOWED, 'Request method not supported.')
+  return _FormatResult(result)
+
+
+@webapp.route(
+  '/GridCellsMetaData/<zoom>',
+  methods=['GET', 'PUT', 'POST', 'DELETE'])
+def GridCellsMetaDataHandler(zoom):
+  """Handles the web service request for multi-grid operations.
+
+  Args:
+    zoom: zoom level in slippy tile format
+    x: x tile number in slippy tile format
+    y: y tile number in slippy tile format
+    OAuth access_token as part of the header
+    Plus posted webargs:
+      coords: csv of lon,lat,long,lat,etc.
+      coord_type: (optional) type of coords - point (default), path, polygon
+      and additional as needed for PUT/POST and DELETE methods (see below)
+  Returns:
+    200 with token and metadata in JSON format,
+    or the nominal 4xx error codes as necessary.
+  """
+  uss_id = _ValidateAccessToken()
+  result = {}
+  try:
+    zoom = int(zoom)
+    tiles = _ConvertCSVtoTiles(zoom)
+    if len(tiles) > TILE_LIMIT:
+      raise OverflowError('Limit of %d tiles impacted exceeded (%d)'
+                          % (TILE_LIMIT, len(tiles)))
+  except (ValueError, TypeError) as e:
+    abort(status.HTTP_400_BAD_REQUEST, e.message)
+  except OverflowError as e:
+    abort(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, e.message)
+  if request.method == 'GET':
+    result = _GetGridCellsMetaData(zoom, tiles)
+  elif request.method in ('PUT', 'POST'):
+    result = _PutGridCellsMetaData(zoom, tiles, uss_id)
+  elif request.method == 'DELETE':
+    result = _DeleteGridCellsMetaData(zoom, tiles, uss_id)
   else:
     abort(status.HTTP_405_METHOD_NOT_ALLOWED, 'Request method not supported.')
   return _FormatResult(result)
@@ -253,8 +282,7 @@ def _GetGridCellMetaData(zoom, x, y):
   """Provides an instantaneous snapshot of the metadata for a specific GridCell.
 
   GridCellMetaData provides an instantaneous snapshot of the metadata stored
-  in a specific GridCell, along with a token to be used when updating. For
-  TCL3, this will support a single cell.
+  in a specific GridCell, along with a token to be used when updating.
 
   Args:
     zoom: zoom level in slippy tile format
@@ -274,9 +302,9 @@ def _PutGridCellMetaData(zoom, x, y, uss_id):
   """Updates the metadata stored in a specific slippy GridCell.
 
     Updates the metadata stored in a specific GridCell using optimistic locking
-    behavior, which acquires and releases the lock for the specific GridCell.
-    Operation fails if unable to acquire the locks or if the lock has been
-    updated since GET GridCellMetadata was originally called (based on token).
+    behavior. Operation fails if the metadata has been updated since
+    GET GridCellMetadata was originally called (based on token).
+
   Args:
     zoom: zoom level in slippy tile format
     x: x tile number in slippy tile format
@@ -349,9 +377,7 @@ def _PutGridCellMetaData(zoom, x, y, uss_id):
 def _DeleteGridCellMetaData(zoom, x, y, uss_id):
   """Removes the USS entry in the metadata stored in a specific GridCell.
 
-  Removes the USS entry in the metadata using optimistic locking behavior, which
-  acquires and releases the lock for the specific GridCell. Operation fails if
-  unable to acquire the locks.
+  Removes the USS entry in the metadata using optimistic locking behavior.
 
   Args:
     zoom: zoom level in slippy tile format
@@ -378,6 +404,149 @@ def _DeleteGridCellMetaData(zoom, x, y, uss_id):
               delete a USS from a GridCell."""
     }
   return result
+
+
+def _GetGridCellsMetaData(zoom, tiles):
+  """Provides an instantaneous snapshot of the metadata for a multiple GridCells
+
+  Args:
+    zoom: zoom level in slippy tile format
+    tiles: array of x,y tiles to retrieve
+  Returns:
+    200 with token and JSON metadata,
+    or the nominal 4xx error codes as necessary.
+  """
+  log.info('Grid cells metadata request instantiated for %sz, %s...',
+           zoom, str(tiles))
+  result = wrapper.get_multi(zoom, tiles)
+  return result
+
+def _PutGridCellsMetaData(zoom, tiles, uss_id):
+  """Updates the metadata stored in multiple GridCells.
+
+    Updates the metadata stored in a multiple GridCell using optimistic locking
+    behavior. Operation fails if the metadata has been updated since
+    GET GridCellsMetadata was originally called (based on sync_token).
+
+  Args:
+    zoom: zoom level in slippy tile format
+    tiles: array of x,y tiles to retrieve
+    uss_id: the plain text identifier for the USS from OAuth
+  Plus posted webargs:
+    sync_token: the composite sync_token retrieved in the
+      original GET GridCellsMetadata,
+    scope: The submitting USS scope for the web service endpoint (used for OAuth
+      access),
+    operation_endpoint: the submitting USS endpoint where all flights in these
+      cells can be retrieved from (variables {zoom}, {x}, and {y} can be used in
+      the endpoint, and will be replaced with the actual grid values),
+    operation_format: The output format for the USS web service endpoint (i.e.
+      NASA, GUTMA),
+    minimum_operation_timestamp: the lower time bound of all of the USSs flights
+      in these grid cells.
+    maximum_operation_timestamp: the upper time bound of all of the USSs flights
+      in these grid cells.
+
+  Returns:
+    200 and a new composite token if updated successfully,
+    409 if there is a locking conflict that could not be resolved, or
+    the other nominal 4xx error codes as necessary.
+  """
+  log.info('Grid cells metadata submit instantiated for %s at %sz, %s...',
+           uss_id, zoom, str(tiles))
+  sync_token = _GetRequestParameter('sync_token', None)
+  if not sync_token and 'sync_token' in request.headers:
+    sync_token = request.headers['sync_token']
+  scope = _GetRequestParameter('scope', None)
+  operation_endpoint = _GetRequestParameter('operation_endpoint', None)
+  operation_format = _GetRequestParameter('operation_format', None)
+  minimum_operation_timestamp = _GetRequestParameter(
+    'minimum_operation_timestamp', None)
+  maximum_operation_timestamp = _GetRequestParameter(
+    'maximum_operation_timestamp', None)
+  errorfield = errormsg = None
+  if not sync_token:
+    errorfield = 'sync_token'
+  elif not uss_id:
+    errorfield = 'uss_id'
+    errormsg = 'USS identifier not received from OAuth token check.'
+  elif not scope:
+    errorfield = 'scope'
+  elif not operation_endpoint:
+    errorfield = 'operation_endpoint'
+  elif not operation_format:
+    errorfield = 'operation_format'
+  elif not minimum_operation_timestamp:
+    errorfield = 'minimum_operation_timestamp'
+  elif not maximum_operation_timestamp:
+    errorfield = 'maximum_operation_timestamp'
+  if errorfield:
+    if not errormsg:
+      errormsg = errorfield + (
+        ' must be provided in the form data request to add to a '
+        'GridCell.')
+    result = {
+      'status': 'error',
+      'code': status.HTTP_400_BAD_REQUEST,
+      'message': errormsg
+    }
+  else:
+    result = wrapper.set_multi(zoom, tiles, sync_token, uss_id, scope,
+                         operation_format, operation_endpoint,
+                         minimum_operation_timestamp,
+                         maximum_operation_timestamp)
+  return result
+
+def _DeleteGridCellsMetaData(zoom, tiles, uss_id):
+  """Removes the USS entry in multiple GridCells.
+
+  Args:
+    zoom: zoom level in slippy tile format
+    tiles: array of x,y tiles to delete the uss from
+    uss_id: the plain text identifier for the USS from OAuth
+  Returns:
+    200 and a new sync_token if updated successfully,
+    409 if there is a locking conflict that could not be resolved, or
+    the other nominal 4xx error codes as necessary.
+  """
+  log.info('Grid cells metadata delete instantiated for %s, %sz, %s...',
+           uss_id, zoom, str(tiles))
+  if uss_id:
+    result = wrapper.delete_multi(uss_id, zoom, tiles)
+  else:
+    result = {
+      'status':
+        'fail',
+      'code':
+        status.HTTP_400_BAD_REQUEST,
+      'message':
+        """uss_id must be provided in the request to
+          delete a USS from a GridCell."""
+    }
+  return result
+
+
+def _ConvertCSVtoTiles(zoom):
+  """Converts an CSV of coords into slippy tile format at the specified zoom
+      and the specified coordinate type (path, polygon, point) """
+  tiles = []
+  coords = _GetRequestParameter('coords', '')
+  coord_type = _GetRequestParameter('coord_type', 'point')
+  log.debug('Retrieved coords from web params and split to %s...', coords)
+  coordinates = slippy_util.convert_csv_to_coordinates(coords)
+  if not coordinates:
+    log.error('Invalid coords %s, must be a CSV of lat,lon...', coords)
+    raise ValueError('Invalid coords, must be a CSV of lat,lon,lat,lon...')
+  if coord_type == 'point':
+    for c in coordinates:
+      tiles.append((slippy_util.convert_point_to_tile(zoom, c[0], c[1])))
+  elif coord_type == 'path':
+    tiles = slippy_util.convert_path_to_tiles(zoom, coordinates)
+  elif coord_type == 'polygon':
+    tiles = slippy_util.convert_polygon_to_tiles(zoom, coordinates)
+  else:
+    raise ValueError('Invalid coord_type, must be point/path/polygon')
+  return tiles
 
 
 def _GetRequestParameter(name, default):

--- a/datanode/src/storage_api_test.py
+++ b/datanode/src/storage_api_test.py
@@ -20,6 +20,7 @@ import unittest
 import requests
 
 import storage_api
+
 ZK_TEST_CONNECTION_STRING = 'localhost:2181'
 TESTID = 'storage-api-test'
 
@@ -30,7 +31,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     storage_api.webapp.testing = True
     self.app = storage_api.webapp.test_client()
     options = storage_api.ParseOptions(
-        ['-z', ZK_TEST_CONNECTION_STRING, '-t', TESTID])
+      ['-z', ZK_TEST_CONNECTION_STRING, '-t', TESTID])
     storage_api.InitializeConnection(options)
 
   def tearDown(self):
@@ -59,11 +60,11 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
 
   def testIntrospectWithExpiredToken(self):
     result = self.app.get(
-        '/introspect',
-        headers={
-            'access_token':
-            '1/fFAGRNJru1FTz70BzhT3Zg'
-        })
+      '/introspect',
+      headers={
+        'access_token':
+          '1/fFAGRNJru1FTz70BzhT3Zg'
+      })
     self.assertEqual(400, result.status_code)
 
   def testValidAuthorizationTokensInTest(self):
@@ -144,12 +145,12 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
       j, json.loads(self.app.get(
         '/slippy/13?coords=37.203335,-80.599481,37.20334,-80.59948').data))
     r = self.app.get('/slippy/11?coords=0,0,1,1,2,2,3,3')
-    self.assertEqual(r.status_code, 200)
-    self.assertEqual(len(json.loads(r.data)['data']['grid_cells']), 4)
+    self.assertEqual(200, r.status_code)
+    self.assertEqual(4, len(json.loads(r.data)['data']['grid_cells']))
 
   def testSlippyConversionWithValidPaths(self):
     r = self.app.get('/slippy/0?coord_type=path&coords=0,0,1,1.5')
-    self.assertEqual(r.status_code, 200)
+    self.assertEqual(200, r.status_code)
     j = json.loads(r.data)
     self.assertEqual(0, j['data']['grid_cells'][0]['zoom'])
     self.assertEqual(0, j['data']['grid_cells'][0]['x'])
@@ -160,7 +161,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
       self.app.get('/slippy/5?coord_type=path&coords=0,0,1,1.5').data,
       self.app.get('/slippy/5?coord_type=path&coords=0,0,1,1.5,0,0').data)
     r = self.app.get('/slippy/15?coord_type=path&coords=0,0,1,1.5')
-    self.assertEqual(r.status_code, 200)
+    self.assertEqual(200, r.status_code)
     j = json.loads(r.data)
     self.assertEqual(15, j['data']['grid_cells'][0]['zoom'])
     self.assertEqual(229, len(j['data']['grid_cells']))
@@ -173,7 +174,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
 
   def testSlippyConversionWithValidPolygons(self):
     r = self.app.get('/slippy/0?coord_type=polygon&coords=0,0,1,1.5,0,1.5')
-    self.assertEqual(r.status_code, 200)
+    self.assertEqual(200, r.status_code)
     j = json.loads(r.data)
     self.assertEqual(0, j['data']['grid_cells'][0]['zoom'])
     self.assertEqual(0, j['data']['grid_cells'][0]['x'])
@@ -186,7 +187,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
         '/slippy/5?coord_type=polygon&coords=0,0,1,1.5,0,0,0,1.5,0,0').data)
     s = '47.5,-103,47.5,-101.8,48,-101.8,48,-103,47.5,-103'
     r = self.app.get('/slippy/9?coord_type=polygon&coords=' + s)
-    self.assertEqual(r.status_code, 200)
+    self.assertEqual(200, r.status_code)
     j = json.loads(r.data)
     self.assertEqual(9, j['data']['grid_cells'][0]['zoom'])
     self.assertEqual(9, len(j['data']['grid_cells']))
@@ -223,96 +224,96 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     j = json.loads(result.data)
     s = j['sync_token']
     self.assertEqual(404, self.app.put(
-        '/GridCellMetaDatas/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            flight_endpoint='https://g.co/f1',
-            priority_flight_callback='https://g.co/r')).status_code)
+      '/GridCellMetaDatas/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        flight_endpoint='https://g.co/f1',
+        priority_flight_callback='https://g.co/r')).status_code)
     self.assertEqual(404, self.app.put(
-        '/GridCellMetaData',
-        query_string=dict(
-            ssync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData',
+      query_string=dict(
+        ssync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1a/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData/1a/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/99/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData/1/99/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            # sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        # sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            # scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        # scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            # operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        # operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            # operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        # operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            # minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02')).status_code)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        # minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            # maximum_operation_timestamp='2018-01-02'
-            minimum_operation_timestamp='2018-01-01')).status_code)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        # maximum_operation_timestamp='2018-01-02'
+        minimum_operation_timestamp='2018-01-01')).status_code)
     self.assertEqual(400, self.app.put(
-        '/GridCellMetaData/1/1/1', data={
-            'sync_token': 'NOT_VALID'
-        }).status_code)
+      '/GridCellMetaData/1/1/1', data={
+        'sync_token': 'NOT_VALID'
+      }).status_code)
     self.assertEqual(400, self.app.put('/GridCellMetaData/1/1/1').status_code)
 
   def testIncorrectDeletesOnGridCells(self):
@@ -322,7 +323,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     self.assertEqual(404,
                      self.app.delete('/GridCellMetaData/admin').status_code)
     self.assertEqual(404, self.app.delete(
-        '/GridCellMetaData/1/1/1/admin').status_code)
+      '/GridCellMetaData/1/1/1/admin').status_code)
     self.assertEqual(400,
                      self.app.delete('/GridCellMetaData/1a/1/1').status_code)
     self.assertEqual(400,
@@ -349,14 +350,14 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     self.assertEqual(0, len(j['data']['operators']))
     # Put a record in there
     result = self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02'))
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
     self.assertEqual(200, result.status_code)
     j = json.loads(result.data)
     s = j['sync_token']
@@ -369,7 +370,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     result = self.app.get('/GridCellMetaData/1/1/1')
     self.assertEqual(200, result.status_code)
     j = json.loads(result.data)
-    self.assertEqual(len(j['data']['operators']), 0)
+    self.assertEqual(0, len(j['data']['operators']))
 
   def testMultipleUpdates(self):
     # Make sure it is empty
@@ -377,45 +378,314 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     self.assertEqual(200, result.status_code)
     j = json.loads(result.data)
     s = j['sync_token']
-    self.assertEqual(len(j['data']['operators']), 0)
+    self.assertEqual(0, len(j['data']['operators']))
     # Put a record in there with the wrong sequence token
     result = self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token='arbitrary_and_NOT_VALID',
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02'))
-    self.assertEqual(result.status_code, 409)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token='arbitrary_and_NOT_VALID',
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    self.assertEqual(409, result.status_code)
     # Put a record in there with the right sequence token
     result = self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02'))
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
     self.assertEqual(200, result.status_code)
     # Try to put a record in there again with the old sequence token
     result = self.app.put(
-        '/GridCellMetaData/1/1/1',
-        query_string=dict(
-            sync_token=s,
-            scope='https://g.co/r',
-            operation_endpoint='https://g.co/f',
-            operation_format='NASA',
-            minimum_operation_timestamp='2018-01-01',
-            maximum_operation_timestamp='2018-01-02'))
-    self.assertEqual(result.status_code, 409)
+      '/GridCellMetaData/1/1/1',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g.co/r',
+        operation_endpoint='https://g.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    self.assertEqual(409, result.status_code)
+
+  def testMultipleGridCellGets(self):
+    # for this zoom level (10), the points refer to the following tiles:
+    # (512, 512), (512, 509), (514, 509), (514, 512)
+    # Path includes the following (in addition to points):
+    # (512, 510), (512, 511), (513, 509), (514, 511), (514, 510)
+    # Polygon includes the following (in addition to path):
+    # (513, 512), (513, 510),(513, 511)
+    # Make sure it is empty, try points first
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    multisync = j['sync_token']
+    self.assertEqual(0, len(j['data']['operators']))
+    # Now write to one and make sure the sync token changes
+    result = self.app.get('/GridCellMetaData/10/512/512')
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(0, len(j['data']['operators']))
+    # Put a record in one of the cells
+    self.app.put(
+      '/GridCellMetaData/10/512/512',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g1.co/r',
+        operation_endpoint='https://g1.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertNotEqual(multisync, j['sync_token'])
+    self.assertEqual(1, len(j['data']['operators']))
+    # Now do it with a path
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(
+                            coords='0,0,1,0,1,1,0,1',
+                            coord_type='path'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(1, len(j['data']['operators']))
+    # Put a record in one of the cells that only applies to the path
+    result = self.app.get('/GridCellMetaData/10/512/510')
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(0, len(j['data']['operators']))
+    self.app.put(
+      '/GridCellMetaData/10/512/510',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g2.co/r',
+        operation_endpoint='https://g2.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1',
+                                            coord_type='path'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(2, len(j['data']['operators']))
+    # and make sure only one still in the point method
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(1, len(j['data']['operators']))
+    # and a polygon, add a record only applies to the polygon grid
+    result = self.app.get('/GridCellMetaData/10/513/511')
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(0, len(j['data']['operators']))
+    self.app.put(
+      '/GridCellMetaData/10/513/511',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g3.co/r',
+        operation_endpoint='https://g3.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1',
+                                            coord_type='polygon'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(3, len(j['data']['operators']))
+    # and make sure only one still in the point method
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(1, len(j['data']['operators']))
+
+  def testMultipleGridCellDeletes(self):
+    # Put a record in two of the cells
+    result = self.app.get('/GridCellMetaData/10/512/512')
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(0, len(j['data']['operators']))
+    self.app.put(
+      '/GridCellMetaData/10/512/512',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g1.co/r',
+        operation_endpoint='https://g1.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    result = self.app.get('/GridCellMetaData/10/512/510')
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(0, len(j['data']['operators']))
+    result = self.app.put(
+      '/GridCellMetaData/10/512/510',
+      query_string=dict(
+        sync_token=s,
+        scope='https://g2.co/r',
+        operation_endpoint='https://g2.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    # Put a record for a different USS in one of the cells
+    self.assertEqual(1, len(j['data']['operators']))
+    result = self.app.put(
+      '/GridCellMetaData/10/512/510',
+      headers={'access_token': TESTID + '3'},
+      query_string=dict(
+        sync_token=s,
+        scope='https://g3.co/r',
+        operation_endpoint='https://g3.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    # Now delete the first USS from all cells, leaving just the uss#3
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1',
+                                            coord_type='polygon'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(3, len(j['data']['operators']))
+    result = self.app.delete('/GridCellsMetaData/10',
+                             query_string=dict(coords='0,0,1,0,1,1,0,1',
+                                               coord_type='polygon'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(1, len(j['data']['operators']))
+
+  def testMultipleGridCellPut(self):
+    # for this zoom level (10), the points refer to the following tiles:
+    # (512, 512), (512, 509), (514, 509), (514, 512)
+    # Path includes the following (in addition to points):
+    # (512, 510), (512, 511), (513, 509), (514, 511), (514, 510)
+    # Polygon includes the following (in addition to path):
+    # (513, 512), (513, 510),(513, 511)
+    # Make sure it is empty, try points first
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(0, len(j['data']['operators']))
+    # Put a record in all of the point cells
+    result = self.app.put(
+      '/GridCellsMetaData/10',
+      headers={'access_token': TESTID + '1'},
+      query_string=dict(
+        coords='0,0,1,0,1,1,0,1',
+        sync_token=s,
+        scope='https://g1.co/r',
+        operation_endpoint='https://g1.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertNotEqual(s, j['sync_token'])
+    s = j['sync_token']
+    self.assertEqual(4, len(j['data']['operators']))
+    # Now do it with a path
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(
+                            coords='0,0,1,0,1,1,0,1',
+                            coord_type='path'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(4, len(j['data']['operators']))
+    # Put a record in all of the path cells
+    result = self.app.put(
+      '/GridCellsMetaData/10',
+      headers={'access_token': TESTID + '2'},
+      query_string=dict(
+        coords='0,0,1,0,1,1,0,1',
+        coord_type='path',
+        sync_token=s,
+        scope='https://g2.co/r',
+        operation_endpoint='https://g2.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(4 + 9, len(j['data']['operators']))
+    # and make sure eight in the point method
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(4 + 4, len(j['data']['operators']))
+    # and a polygon, add records that applies to the polygon grid
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(
+                            coords='0,0,1,0,1,1,0,1',
+                            coord_type='polygon'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(4 + 9, len(j['data']['operators']))
+    result = self.app.put(
+      '/GridCellsMetaData/10',
+      headers={'access_token': TESTID + '3'},
+      query_string=dict(
+        coords='0,0,1,0,1,1,0,1',
+        coord_type='polygon',
+        sync_token=s,
+        scope='https://g3.co/r',
+        operation_endpoint='https://g3.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    self.assertEqual(4 + 9 + 12, len(j['data']['operators']))
+
+  def testMultipleGridCellFailures(self):
+    self.assertEqual(400, self.app.get('/GridCellsMetaData/10',
+                                       query_string=dict(
+                                         coords='0,0,1')).status_code)
+    self.assertEqual(400, self.app.get('/GridCellsMetaData/10',
+                                       query_string=dict(
+                                         coords='0,0,1,0,1,1,0,1',
+                                         coord_type='rainbows')).status_code)
+    result = self.app.get('/GridCellsMetaData/10',
+                          query_string=dict(coords='0,0,1,0,1,1,0,1'))
+    self.assertEqual(200, result.status_code)
+    j = json.loads(result.data)
+    s = j['sync_token']
+    self.assertEqual(400, self.app.put(
+      '/GridCellsMetaData/10',
+      query_string=dict(
+        coords='0,0,1',
+        sync_token=s,
+        scope='https://g1.co/r',
+        operation_endpoint='https://g1.co/f',
+        operation_format='NASA',
+        minimum_operation_timestamp='2018-01-01',
+        maximum_operation_timestamp='2018-01-02')).status_code)
 
   def testVerbose(self):
     options = storage_api.ParseOptions([
-        '-z', ZK_TEST_CONNECTION_STRING, '-t', TESTID,
-        '-v'
+      '-z', ZK_TEST_CONNECTION_STRING, '-t', TESTID,
+      '-v'
     ])
     storage_api.InitializeConnection(options)
 

--- a/datanode/src/storage_api_test.py
+++ b/datanode/src/storage_api_test.py
@@ -160,16 +160,13 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     self.assertEqual(
       self.app.get('/slippy/5?coord_type=path&coords=0,0,1,1.5').data,
       self.app.get('/slippy/5?coord_type=path&coords=0,0,1,1.5,0,0').data)
-    r = self.app.get('/slippy/15?coord_type=path&coords=0,0,1,1.5')
-    self.assertEqual(200, r.status_code)
-    j = json.loads(r.data)
-    self.assertEqual(15, j['data']['grid_cells'][0]['zoom'])
-    self.assertEqual(229, len(j['data']['grid_cells']))
 
   def testSlippyConversionWithInvalidPaths(self):
     r = self.app.get('/slippy/0?coord_type=path&coords=0')
     self.assertEqual(400, r.status_code)
     r = self.app.get('/slippy/0?coord_type=path&coords=0,1,2')
+    self.assertEqual(400, r.status_code)
+    r = self.app.get('/slippy/15?coord_type=path&coords=0,0,1,1.5')
     self.assertEqual(400, r.status_code)
 
   def testSlippyConversionWithValidPolygons(self):
@@ -666,6 +663,10 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
                                        query_string=dict(
                                          coords='0,0,1,0,1,1,0,1',
                                          coord_type='rainbows')).status_code)
+    self.assertEqual(413, self.app.get('/GridCellsMetaData/18',
+                                       query_string=dict(
+                                         coords='0,0,1,0,1,1,0,1',
+                                         coord_type='polygon')).status_code)
     result = self.app.get('/GridCellsMetaData/10',
                           query_string=dict(coords='0,0,1,0,1,1,0,1'))
     self.assertEqual(200, result.status_code)

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -60,7 +60,7 @@ BAD_CHARACTER_CHECK = '\';(){}[]!@#$%^&*|"<>'
 CONNECTION_TIMEOUT = 2.5  # seconds
 DEFAULT_CONNECTION = 'localhost:2181'
 GRID_PATH = USS_BASE_PREFIX
-
+MAX_SAFE_INTEGER = 9007199254740991
 
 class USSMetadataManager(object):
   """Interfaces with the locking system to get, put, and delete USS metadata.
@@ -597,6 +597,9 @@ class USSMetadataManager(object):
 
   @staticmethod
   def _hash_sync_tokens(syncs):
-    """Hashes a list of sync tokens into a single, positive 64-bit int"""
-    log.debug('Hashing syncs: %s', tuple(sorted(syncs)))
-    return abs(hash(tuple(sorted(syncs))))
+    """Hashes a list of sync tokens into a single, positive 64-bit int.
+
+    For various languages, the limit to integers may be different, therefore
+    we truncate to ensure the hash is the same on all implementations.
+    """
+    return abs(hash(tuple(sorted(syncs)))) % MAX_SAFE_INTEGER

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -362,7 +362,7 @@ class USSMetadataManager(object):
       result = self._format_status_code_to_jsend(404, e.message)
     return result
 
-  def delete_multi(self, uss_id, z, grids):
+  def delete_multi(self, z, grids, uss_id):
     """Sets multiple GridCells metadata by removing the entry for the USS.
 
     Removes the operator from multiple cells. Does not return 404 on
@@ -370,9 +370,9 @@ class USSMetadataManager(object):
     type function, as some cells might have the ussid and some might not.
     
     Args:
-      uss_id: is the plain text identifier for the USS
       z: zoom level in slippy tile format
       grids: list of (x,y) tiles to delete
+      uss_id: is the plain text identifier for the USS
     Returns:
       JSend formatted response (https://labs.omniti.com/labs/jsend)
     """

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -365,10 +365,10 @@ class USSMetadataManager(object):
   def delete_multi(self, uss_id, z, grids):
     """Sets multiple GridCells metadata by removing the entry for the USS.
 
-    Reads data from zookeeper, including a snapshot token. The
-    snapshot token is used as a reference when writing to ensure
-    the data has not been updated between read and write.
-
+    Removes the operator from multiple cells. Does not return 404 on
+    not finding the USS in a cell, since this should be a remove all
+    type function, ad some cells might have the ussid and some might not.
+    
     Args:
       uss_id: is the plain text identifier for the USS
       z: zoom level in slippy tile format

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -367,7 +367,7 @@ class USSMetadataManager(object):
 
     Removes the operator from multiple cells. Does not return 404 on
     not finding the USS in a cell, since this should be a remove all
-    type function, ad some cells might have the ussid and some might not.
+    type function, as some cells might have the ussid and some might not.
     
     Args:
       uss_id: is the plain text identifier for the USS

--- a/datanode/src/storage_interface_test.py
+++ b/datanode/src/storage_interface_test.py
@@ -278,7 +278,7 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
                     '2018-01-01T01:00:00+00:00')
     self.assertEqual('success', s['status'])
     # Now try deleting uss1, which would delete from two different cells
-    r2 = self.mm.delete_multi('uss1', 7, grids)
+    r2 = self.mm.delete_multi(7, grids, 'uss1')
     self.assertEqual('success', r2['status'])
     self.assertNotEqual(r1['sync_token'], r2['sync_token'])
     self.assertEqual(3, r2['data']['version'])
@@ -289,9 +289,9 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
     self.assertEqual('fail', r['status'])
     r = self.mm.get_multi(6, '0,0,1,1,0,1')
     self.assertEqual('fail', r['status'])
-    r = self.mm.delete_multi(None, 6, [(0, 0), (0, 1), (1, 1)])
+    r = self.mm.delete_multi(6, [(0, 0), (0, 1), (1, 1)], None)
     self.assertEqual('fail', r['status'])
-    r = self.mm.delete_multi('uss', 21, [(0, 0), (0, 1), (1, 1)])
+    r = self.mm.delete_multi(21, [(0, 0), (0, 1), (1, 1)], 'uss')
     self.assertEqual('fail', r['status'])
 
   def testSetMultipleCellCases(self):

--- a/datanode/src/storage_interface_test.py
+++ b/datanode/src/storage_interface_test.py
@@ -168,7 +168,8 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
           ))
       threads.append(t)
       t.start()
-    t.join()
+    for t in threads:
+      t.join()
     # confirm there is only one update
     g = self.mm.get(4, 1, 1)
     self.assertEqual('success', g['status'])


### PR DESCRIPTION
Added endpoint /GridCellsMetaData to support multiple grid changes via a set of points, a path or an enclosed polygon. This fixes Issue #35 .

Swaggerhub is updated as well as the server that drives it, available here to test:
https://app.swaggerhub.com/apis/InterUSS_Platform/data_node_api/1.1.0

