### PR TITLE
Add real-time monitoring tools

### DIFF
--- a/datanode/tools/client_tools.py
+++ b/datanode/tools/client_tools.py
@@ -1,0 +1,130 @@
+"""Utilities for interacting with TCL4 InterUSS Platform Data Nodes.
+
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import os
+
+import requests
+
+try:
+  from urllib.request import Request, urlopen, HTTPError  # Python 3
+except ImportError:
+  from urllib2 import Request, urlopen, HTTPError  # Python 2
+
+DEFAULT_AUTH_URL = 'https://utmalpha.arc.nasa.gov/fimsAuthServer/oauth/token?grant_type=client_credentials'
+DEFAULT_HOST = 'http://18.216.177.215:8120/'
+DEFAULT_REQUEST_PATH = 'GridCellsOperator/10?coords=48.3379,-103.4582,47.6191,-103.1149,47.5672,-102.4530,48.3525,-102.4722,48.3379,-103.4582&coord_type=polygon'
+
+def get_token(auth_key, auth_url):
+  """Call the specified OAuth server to retrieve an access token.
+
+  Args:
+    auth_key: Base64-encoded username and password.
+    auth_url: URL the provides an access token.
+
+  Returns:
+    Access token for TCL4 InterUSS Platform data node.
+
+  Raises:
+    ValueError: When access_token was not returned properly.
+  """
+  r = requests.post(auth_url, headers={'Authorization': 'Basic ' + auth_key})
+  result = r.content
+  result_json = json.loads(result)
+  if 'access_token' in result_json:
+    return result_json['access_token']
+  else:
+    raise ValueError('Error getting token: ' + r.content)
+
+def get_metadata(token, url):
+  """Retrieve metadata from TCL4 InterUSS Platform data node.
+
+  Args:
+    token: Access token acquired from OAuth server.
+    url: GridCellOperators endpoint of data node.
+
+  Returns:
+    USS Metadata JSON string returned from GridCellOperators endpoint.
+
+  Raises:
+    ValueError: When result does not contain valid JSON.
+  """
+  r = requests.get(url, headers={
+    'Cache-Control': 'no-cache', 'access_token': token})
+  try:
+    json.loads(r.content)
+  except ValueError:
+    raise ValueError('Error getting metadata: ' + r.content)
+  return r.content
+
+def add_auth_arguments(parser):
+  """Add arguments relating to OAuth authentication.
+
+  Args:
+    parser: argparser to mutate with additional arguments.
+  """
+  parser.add_argument(
+    '-k',
+    '--auth_key',
+    dest='auth_key',
+    default=os.environ.get('AUTH_KEY', None),
+    help='Base64-encoded username and password to pass to the OAuth server as '
+         'Basic XXX in the Authentication header. Defaults to AUTH_KEY '
+         'environment variable if defined',
+    metavar='AUTH_KEY')
+  parser.add_argument(
+    '-a',
+    '--auth_url',
+    dest='auth_url',
+    default=DEFAULT_AUTH_URL,
+    help='URL from which to obtain an access token',
+    metavar='URL')
+
+def add_node_arguments(parser):
+  """Add arguments relating to TCL4 InterUSS Platform data node access.
+
+  Args:
+    parser: argparser to mutate with additional arguments.
+  """
+  parser.add_argument(
+    '-n',
+    '--node',
+    dest='node',
+    default=DEFAULT_HOST,
+    help='Host name of TCL4 InterUSS Platform node to poll',
+    metavar='HOST')
+  parser.add_argument(
+    '-r',
+    '--request_path',
+    dest='request_path',
+    default=DEFAULT_REQUEST_PATH,
+    help='Path and query to use on the TCL4 InterUSS Platform node',
+    metavar='REQUESTPATH')
+
+def make_node_url(options):
+  """Combine option values from node arguments into a URL for that node.
+
+  Args:
+    options: Parsed options from argparser which included arguments from
+      add_node_arguments.
+
+  Returns:
+    URL to TCL4 InterUSS Platform data node endpoint.
+  """
+  return (options.node + ('' if options.node.endswith('/') else '/') +
+          options.request_path)

--- a/datanode/tools/get_token
+++ b/datanode/tools/get_token
@@ -1,0 +1,37 @@
+#!/usr/bin/env python2
+
+"""Tool to retrieve a token for a TCL4 InterUSS Platform Data Node.
+
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+
+import client_tools
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(
+    description='Retrieve and print an access_token for accessing a TCL4 '
+                'InterUSS Platform node. To cache this token, you may want to '
+                'run:\n'
+                'export ACCESS_TOKEN=`./get_token`')
+  client_tools.add_auth_arguments(parser)
+
+  options = parser.parse_args()
+
+  token = client_tools.get_token(options.auth_key, options.auth_url)
+  print(token)

--- a/datanode/tools/monitor
+++ b/datanode/tools/monitor
@@ -1,0 +1,158 @@
+#!/usr/bin/env python2
+
+"""Tool to monitor a TCL4 InterUSS Platform Data Node in real time.
+
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import copy
+import datetime
+import glob
+import json
+import os
+import sys
+import time
+
+import termcolor
+
+import client_tools
+import reports
+
+DEFAULT_POLL_INTERVAL = 5  # seconds
+
+def print_no_newline(s):
+  """Print a string without a trailing newline.
+
+  Args:
+    s: String to print.
+  """
+  sys.stdout.write(s)
+  sys.stdout.flush()
+
+def metadata_diff(old_metadata, new_metadata):
+  """Return a USS Metadata dict containing only operators different in new relative to old.
+
+  Args:
+    old_metadata: USS Metadata dict translated from JSON returned from GridCellOperators endpoint.
+    new_metadata: USS Metadata dict translated from JSON returned from GridCellOperators endpoint.
+
+  Returns:
+    USS Metadata dict with only changed operators between old and new.
+  """
+  diff = copy.deepcopy(new_metadata)
+  diff['data']['operators'] = []
+  def operator_name(entry):
+    return '%s %d(%d, %d)' % (
+      entry['uss'], entry['zoom'], entry['x'], entry['y'])
+  old_operators = {operator_name(entry): entry
+                   for entry in old_metadata['data']['operators']}
+  new_operators = {operator_name(entry): entry
+                   for entry in new_metadata['data']['operators']}
+
+  for name, new_operator in new_operators.items():
+    old_operator = old_operators.get(name, None)
+    if old_operator and old_operator['version'] == new_operator['version']:
+      continue
+    diff['data']['operators'].append(new_operator)
+
+  return diff
+
+def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds):
+  """Poll a TCL4 InterUSS Platform node and print and log any changes.
+
+  Args:
+    auth_key: Base64 user name and password for OAuth server.
+    auth_url: URL of OAuth server.
+    output_path: Local path to write JSON logs.
+    node_url: URL of GridCellOperators TCL4 InterUSS Platform node endpoint.
+    poll_interval_seconds: Number of seconds to wait between polling operations.
+  """
+
+  # Get an access token
+  token = client_tools.get_token(auth_key, auth_url)
+
+  old_metadata = {'sync_token': None, 'data': {'operators': []}}
+  if output_path:
+    # Continue from where we left off
+    files = sorted(glob.glob(os.path.join(output_path, '*_*.json')))
+    if files:
+      with open(files[-1], 'r') as f:
+        old_metadata = json.loads(f.read())
+
+  first_time = True
+
+  # Polling loop
+  while True:
+    # Poll metadata, refreshing access_token if necessary
+    try:
+      new_metadata_string = client_tools.get_metadata(token, node_url)
+    except ValueError:
+      print('')
+      print('Access token expired; getting new one...')
+      token = client_tools.get_token(auth_key, auth_url)
+      print('Updated access token: ' + token)
+      new_metadata_string = client_tools.get_metadata(token, node_url)
+
+    new_metadata = json.loads(new_metadata_string)
+    if new_metadata['sync_token'] != old_metadata['sync_token']:
+      # Data has changed; print out the changes
+      print('')
+      reports.print_operators(metadata_diff(old_metadata, new_metadata))
+
+      if output_path:
+        filename = os.path.join(
+          output_path,
+          datetime.datetime.now().strftime('%Y%m%d_%H%M%S') + '.json')
+        with open(filename, 'w') as f:
+          f.write(new_metadata_string)
+
+      old_metadata = new_metadata
+
+      if first_time:
+        if not output_path:
+          print(termcolor.colored(
+            '*** WARNING: Not logging changes to disk ***', 'red', attrs=['blink']))
+        first_time = False
+    else:
+      print_no_newline('.')
+    time.sleep(poll_interval_seconds)
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(
+    description='Monitor TCL4 InterUSS Platform grid cell metadata in real '
+                'time, logging and displaying changes')
+  client_tools.add_auth_arguments(parser)
+  client_tools.add_node_arguments(parser)
+  parser.add_argument(
+    '-o',
+    '--output_path',
+    dest='output_path',
+    help='Local filesystem path in which to write JSON server responses',
+    metavar='OUTPUT_PATH')
+  parser.add_argument(
+    '-p',
+    '--poll_interval',
+    dest='poll_interval',
+    default=DEFAULT_POLL_INTERVAL,
+    help='Number of seconds to wait in between polling InterUSS Platform node',
+    metavar='INTERVAL')
+  options = parser.parse_args()
+
+  node_url = client_tools.make_node_url(options)
+
+  loop(options.auth_key, options.auth_url, options.output_path, node_url,
+       options.poll_interval)

--- a/datanode/tools/report
+++ b/datanode/tools/report
@@ -1,0 +1,53 @@
+#!/usr/bin/env python2
+
+"""Tool to qeury the state of a TCL4 InterUSS Platform Data Node.
+
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+import os
+
+import client_tools
+import reports
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(
+    description='Report the status of TCL4 InterUSS Platform grid cell '
+                'in human-readable format')
+  client_tools.add_auth_arguments(parser)
+  client_tools.add_node_arguments(parser)
+  parser.add_argument(
+    '-t',
+    '--access_token',
+    dest='access_token',
+    default=os.environ.get('ACCESS_TOKEN', None),
+    help='OAuth access_token to access the TCL4 InterUSS Platform node. '
+         'Defaults to ACCESS_TOKEN environment variable if defined',
+    metavar='ACCESS_TOKEN')
+
+  options = parser.parse_args()
+
+  if options.access_token:
+    token = options.access_token
+  else:
+    token = client_tools.get_token(options.auth_key, options.auth_url)
+  node_url = client_tools.make_node_url(options)
+  json_string = client_tools.get_metadata(token, node_url)
+  metadata = json.loads(json_string)
+  reports.print_operators(metadata)

--- a/datanode/tools/reports.py
+++ b/datanode/tools/reports.py
@@ -1,0 +1,130 @@
+"""Utilities for printing data from TCL4 InterUSS Platform Data Nodes.
+
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import datetime
+
+import pytz
+import termcolor
+
+
+def parse_timestamp(timestamp):
+  """Parse a timestamp from the data node into a tz-aware datetime.
+
+  Args:
+    timestamp: String describing timestamp.
+
+  Returns:
+    Time-zone aware datetime in UTC time zone.
+  """
+  return datetime.datetime.strptime(
+    timestamp, '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=pytz.UTC)
+
+def format_timedelta(td):
+  """Produce a human-readable string describing a timedelta.
+
+  Args:
+    td: datetime.timedelta to format.
+
+  Return:
+    Formatted timedelta that looks like HH:MM:SS or XXXdHH:MM:SS where XXX is
+    number of days, with or without a leading negative sign.
+  """
+  seconds = int(td.total_seconds())
+  if seconds < 0:
+    seconds = -seconds
+    sign = '-'
+  else:
+    sign = ''
+  periods = (('%d', 60*60*24), ('%02d', 60*60), ('%02d', 60), ('%02d', 1))
+  has_days = seconds >= periods[0][1]
+
+  segments = []
+  for format_string, period_seconds in periods:
+    period_value, seconds = divmod(seconds, period_seconds)
+    segments.append(format_string % period_value)
+
+  if has_days:
+    return sign + '{:s}d{:s}:{:s}:{:s}'.format(*segments)
+  else:
+    return sign + '{:s}:{:s}:{:s}'.format(*segments[1:])
+
+
+def print_operator_list(operators, now):
+  """Print human-readable summary of operators.
+
+  Timestamps are printed as timedeltas relative to the provided now, and are
+  highlighted when there may be a problem (start time too far in the future, end
+  time in the past)
+
+  Args:
+    operators: List of TCL4 InterUSS Platform Operator dicts.
+    now: The datetime relative to which timestamps should be displayed.
+  """
+  for operator in operators:
+    time_begin = parse_timestamp(operator['minimum_operation_timestamp'])
+    time_end = parse_timestamp(operator['maximum_operation_timestamp'])
+    td_begin = time_begin - now
+    td_end = time_end - now
+    begin_text = format_timedelta(time_begin - now)
+    end_text = format_timedelta(time_end - now)
+    if td_begin > datetime.timedelta(minutes=5):
+      begin_text = termcolor.colored(begin_text, 'red')
+    elif td_begin.total_seconds() > 0:
+      begin_text = termcolor.colored(begin_text, 'yellow')
+    if td_end.total_seconds() < 0:
+      end_text = termcolor.colored(end_text, 'red')
+    print '== %s %d(%d, %d) v%d %s (%s => %s)' % (
+      termcolor.colored(operator['uss'], 'blue'),
+      operator['zoom'], operator['x'], operator['y'], operator['version'],
+      operator['announcement_level'], begin_text, end_text)
+    for operation in operator['operations']:
+      time_begin = parse_timestamp(operation['effective_time_begin'])
+      time_end = parse_timestamp(operation['effective_time_end'])
+      td_begin = time_begin - now
+      td_end = time_end - now
+      begin_text = format_timedelta(time_begin - now)
+      end_text = format_timedelta(time_end - now)
+      if td_begin > datetime.timedelta(minutes=5):
+        begin_text = termcolor.colored(begin_text, 'red')
+      elif td_begin.total_seconds() > 0:
+        begin_text = termcolor.colored(begin_text, 'yellow')
+      if td_end.total_seconds() < 0:
+        end_text = termcolor.colored(end_text, 'red')
+      print '     %s (%s => %s)' % (
+        termcolor.colored(operation['gufi'], 'magenta'),
+        begin_text, end_text)
+
+def print_operators(metadata):
+  """Print human-readable summary of all operators in provided metadata.
+
+  Inactive (no-operation) operators are displayed first in alphabetical order,
+  followed by active (at least one operation) operators in alphabetical order.
+
+  Args:
+    metadata: USS Metadata dict translated from JSON returned from
+      GridCellOperators endpoint.
+  """
+  now = pytz.timezone('US/Pacific').localize(datetime.datetime.now())
+  print('sync_token %s @ %s received %s' % (
+    metadata['sync_token'], metadata['data']['timestamp'], str(now)))
+  passive_operators = sorted([o for o in metadata['data']['operators']
+                              if not o['operations']], key=lambda o: o['uss'])
+  active_operators = sorted([o for o in metadata['data']['operators']
+                             if o['operations']], key=lambda o: o['uss'])
+  print_operator_list(passive_operators, now)
+  print_operator_list(active_operators, now)


### PR DESCRIPTION
This PR adds three tools to help with real-time monitoring, like during a shakedown.

```report``` reports the instantaneous status of Operators in a node.

```monitor``` polls a node and reports changes in Operators in that node.

```get_token``` retrieves an OAuth token, and can be used to avoid repeated calls to the OAuth server when using ```report```.