### PR TITLE
Only iterate through JSON 'uvr' field if it is present

### DIFF
--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -89,7 +89,8 @@ import uvrs
 # VERSION = 'TCL4.0.1.006'  # Corrected error codes and text
 # VERSION = 'TCL4.0.1.007'  # Fixed non-tz aware dates and version in operations
 # VERSION = 'TCL4.0.2.008'  # sync with master branch for multi-grid and docker updates
-VERSION = 'TCL4.0.3.009'  # Added support for UVRs
+# VERSION = 'TCL4.0.3.009'  # Added support for UVRs
+VERSION = 'TCL4.0.3.010'  # Fixed backwards compatibility issue
 
 # Initialize everything we need
 TESTID = None

--- a/datanode/src/uss_metadata.py
+++ b/datanode/src/uss_metadata.py
@@ -109,7 +109,10 @@ class USSMetadata(object):
       self.version = m['version']
       self.timestamp = m['timestamp']
       self.operators = m['operators']
-      self.uvrs = [uvrs.Uvr(j) for j in m['uvrs']]
+      if 'uvrs' in m:
+        self.uvrs = [uvrs.Uvr(j) for j in m['uvrs']]
+      else:
+        self.uvrs = []
     else:
       self.version = 0
       self.timestamp = format_utils.format_ts()


### PR DESCRIPTION
When 4.0.3 was deployed to servers still using previous-version metadata, it would fail when trying to parse that old metadata which does not match the current spec.  This PR provides backwards compatibility by tolerating missing 4.0.3 fields when parsing.