### PR TITLE
Implement public portal API changes

### DIFF
--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -72,7 +72,8 @@ import slippy_util
 # VERSION = '1.0.2.002'  # Standardize OAuth Authorization header, docker fix
 # VERSION = '1.0.2.003'  # slippy utility updates to support point/path/polygon
 # VERSION = '1.0.2.004'  # slippy non-breaking api changes to support path/polygon
-VERSION = '1.1.0.005'  # api changes to support multi-grid GET/PUT/DEL
+# VERSION = '1.1.0.005'  # api changes to support multi-grid GET/PUT/DEL
+VERSION = '1.1.1.006'  # Added public portal support
 
 TESTID = None
 
@@ -334,28 +335,33 @@ def _PutGridCellMetaData(zoom, x, y, uss_id):
   if not sync_token and 'sync_token' in request.headers:
     sync_token = request.headers['sync_token']
   scope = _GetRequestParameter('scope', None)
-  operation_endpoint = _GetRequestParameter('operation_endpoint', None)
-  operation_format = _GetRequestParameter('operation_format', None)
+  operation_endpoint = _GetRequestParameter('operation_endpoint', '')
+  operation_format = _GetRequestParameter('operation_format', '')
   minimum_operation_timestamp = _GetRequestParameter(
       'minimum_operation_timestamp', None)
   maximum_operation_timestamp = _GetRequestParameter(
       'maximum_operation_timestamp', None)
+  public_portal_endpoint = _GetRequestParameter('public_portal_endpoint', '')
+  flight_info_endpoint = _GetRequestParameter('flight_info_endpoint', '')
   errorfield = errormsg = None
-  if not sync_token:
+  if operation_endpoint and not sync_token:
     errorfield = 'sync_token'
   elif not uss_id:
     errorfield = 'uss_id'
     errormsg = 'USS identifier not received from OAuth token check.'
   elif not scope:
     errorfield = 'scope'
-  elif not operation_endpoint:
-    errorfield = 'operation_endpoint'
-  elif not operation_format:
+  elif operation_endpoint and not operation_format:
     errorfield = 'operation_format'
   elif not minimum_operation_timestamp:
     errorfield = 'minimum_operation_timestamp'
   elif not maximum_operation_timestamp:
     errorfield = 'maximum_operation_timestamp'
+  elif (not operation_endpoint and
+        not public_portal_endpoint and
+        not flight_info_endpoint):
+    errorfield = ('operation_endpoint, public portal_endpoint, or '
+                  'flight_info_endpoint')
   if errorfield:
     if not errormsg:
       errormsg = errorfield + (
@@ -370,7 +376,8 @@ def _PutGridCellMetaData(zoom, x, y, uss_id):
     result = wrapper.set(zoom, x, y, sync_token, uss_id, scope,
                          operation_format, operation_endpoint,
                          minimum_operation_timestamp,
-                         maximum_operation_timestamp)
+                         maximum_operation_timestamp, public_portal_endpoint,
+                         flight_info_endpoint)
   return result
 
 
@@ -458,23 +465,23 @@ def _PutGridCellsMetaData(zoom, tiles, uss_id):
   if not sync_token and 'sync_token' in request.headers:
     sync_token = request.headers['sync_token']
   scope = _GetRequestParameter('scope', None)
-  operation_endpoint = _GetRequestParameter('operation_endpoint', None)
-  operation_format = _GetRequestParameter('operation_format', None)
+  operation_endpoint = _GetRequestParameter('operation_endpoint', '')
+  operation_format = _GetRequestParameter('operation_format', '')
   minimum_operation_timestamp = _GetRequestParameter(
     'minimum_operation_timestamp', None)
   maximum_operation_timestamp = _GetRequestParameter(
     'maximum_operation_timestamp', None)
+  public_portal_endpoint = _GetRequestParameter('public_portal_endpoint', '')
+  flight_info_endpoint = _GetRequestParameter('flight_info_endpoint', '')
   errorfield = errormsg = None
-  if not sync_token:
+  if operation_endpoint and not sync_token:
     errorfield = 'sync_token'
   elif not uss_id:
     errorfield = 'uss_id'
     errormsg = 'USS identifier not received from OAuth token check.'
   elif not scope:
     errorfield = 'scope'
-  elif not operation_endpoint:
-    errorfield = 'operation_endpoint'
-  elif not operation_format:
+  elif operation_endpoint and not operation_format:
     errorfield = 'operation_format'
   elif not minimum_operation_timestamp:
     errorfield = 'minimum_operation_timestamp'
@@ -492,9 +499,11 @@ def _PutGridCellsMetaData(zoom, tiles, uss_id):
     }
   else:
     result = wrapper.set_multi(zoom, tiles, sync_token, uss_id, scope,
-                         operation_format, operation_endpoint,
-                         minimum_operation_timestamp,
-                         maximum_operation_timestamp)
+                               operation_format, operation_endpoint,
+                               minimum_operation_timestamp,
+                               maximum_operation_timestamp,
+                               public_portal_endpoint,
+                               flight_info_endpoint)
   return result
 
 def _DeleteGridCellsMetaData(zoom, tiles, uss_id):


### PR DESCRIPTION
This PR implements the API changes for [public portal 1.1.0](https://app.swaggerhub.com/apis/InterUSS_Platform/data_node_api/publicportal1.1.0) per issue #50, which mainly consist of adding two fields to each operator entry in GridCellMetaData: `public_portal_endpoint` and `flight_info_endpoint`.

Accompanying the addition of these fields are slightly more tolerant acceptance criteria.  Now, a `sync_token` is only required when specifying an `operation_endpoint`, implying that the participant has deconflicted a flight.  A participant may create an entry in one or more grid cells without a `sync_token` if specifying `public_portal_endpoint` and/or `flight_info_endpoint` but not an `operation_endpoint`.  At least one endpoint must be specified (or else there would be no point in populating the grid).  And, while a `sync_token` may be specified when inserting or updating a public-portal-only entry, if a `sync_token` is specified, it must be valid.