### PR TITLE
Add auth server

### DIFF
--- a/authserver/docker/Dockerfile_authreverseproxy
+++ b/authserver/docker/Dockerfile_authreverseproxy
@@ -1,0 +1,43 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Definition for Docker image that proxies HTTPS traffic to the auth server.
+
+# To build an image from this Dockerfile:
+# docker image build -f Dockerfile_authreverseproxy -t interussplatform/auth_reverse_proxy .
+
+# To run this image, cert.pem and key.pem must be provided for HTTPS.  See the README for how to
+# generate these files.  Then, run the container with:
+# docker run \
+#     -e INTERUSS_AUTH_SERVER="auth_server_ip" -e INTERUSS_AUTH_PORT="5000" \
+#     -p 8121:8121 -d interussplatform/auth_reverse_proxy
+#     -v /local/path/to/cert:/etc/ssl/certs
+#     -v /local/path/to/key:/etc/ssl/private
+
+# Required environment variables:
+#   INTERUSS_AUTH_SERVER: Address of the auth server.
+#   INTERUSS_AUTH_PORT: Port on which the auth server is listening.
+
+# Optional environment variables:
+#   INTERUSS_API_PORT_HTTPS: Port on which the InterUSS API will be served via HTTPS (default 8121).
+
+FROM nginx
+
+COPY nginx_entrypoint.sh .
+
+ENV INTERUSS_AUTH_PORT_HTTPS 8121
+
+CMD ./nginx_entrypoint.sh
+
+EXPOSE $INTERUSS_AUTH_PORT_HTTPS

--- a/authserver/docker/Dockerfile_authserver
+++ b/authserver/docker/Dockerfile_authserver
@@ -1,0 +1,53 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Definition for Docker image that runs an InterUSS Platform auth server.
+
+# To build an image from this Dockerfile:
+# docker image build -f Dockerfile_authserver -t interussplatform/auth_server ../src
+
+# To run this image, change to a working directory containing just public.pem, private.pem, and
+# roster.txt (see `auth_server --help` for details) and then execute:
+# docker run -v `pwd`:/resources -p 8121:8121 -d interussplatform/auth_server
+
+# Optional environment variables:
+#   INTERUSS_AUTH_SERVER: IP address that will respond to auth server requests (default 0.0.0.0).
+#   INTERUSS_AUTH_PORT: Port on which the auth server will be served (default 5000). This port may
+#     also be exposed outside the container with -p flag.
+#   INTERUSS_VERBOSE: True for more log messages from the auth server (default true).
+#   INTERUSS_ISSUER: Text that will appear in 'iss' field of access_tokens (default
+#     interussplatform.com).
+#   INTERUSS_AUTH_EXPIRATION: Number of seconds after issuance that access tokens will expire
+#     (default 3600).
+
+FROM python:2
+
+WORKDIR /usr/src/app
+
+RUN pip install --no-cache-dir flask PyJWT djangorestframework cryptography gunicorn
+
+COPY . .
+
+ENV INTERUSS_AUTH_SERVER 0.0.0.0
+ENV INTERUSS_AUTH_PORT 5000
+ENV INTERUSS_AUTH_VERBOSE true
+ENV INTERUSS_AUTH_ISSUER interussplatform.com
+ENV INTERUSS_AUTH_EXPIRATION 3600
+ENV INTERUSS_AUTH_PUBLIC_KEY /resources/public.pem
+ENV INTERUSS_AUTH_PRIVATE_KEY /resources/private.pem
+ENV INTERUSS_AUTH_ROSTER /resources/roster.txt
+
+CMD gunicorn auth_server:webapp -b ${INTERUSS_AUTH_SERVER}:${INTERUSS_AUTH_PORT} --access-logfile -
+
+EXPOSE $INTERUSS_AUTH_PORT

--- a/authserver/docker/README.md
+++ b/authserver/docker/README.md
@@ -16,12 +16,13 @@ passwords are sent in the clear without an HTTPS wrapper.
 ### Dockerfile_authreverseproxy
 
 This Dockerfile builds an image containing an nginx reverse proxy intended to
-gate requests to the provide HTTPS access to the auth server.
+gate requests and to the provide HTTPS access to the auth server.
 
 ### docker-compose.yaml
 
 This docker-compose configuration brings up an entire InterUSS Platform auth server in a single
-command.  By default, HTTPS access to the server is available on port 8121.
+command (after supplying the required resources).  By default, HTTPS access to the server is
+available on port 8121.
 
 ## Running an auth server
 
@@ -43,13 +44,13 @@ Be careful never to share private.pem.
 
 #### Roster
 
-The core of the auth server is to translate user credentials into access tokens.  A roster defines
+The core of the auth server is translating user credentials into access tokens.  A roster defines
 the set of users, their passwords, and their respective scopes.  Create `roster.txt` in the same
 folder as the key pair above and populate it with one line per user.  Each line should consist of
 the user's username, their hashed password, and the scopes they are to be granted, each of those
 three fields separated by commas (and be careful to eliminate whitespace).  The scopes should be
 separated by spaces.  The hashed password is the SHA256 hash of
-"`InterUSS Platform USERNAME PASSWORD`".  So, if user `wing.com` had password `wing`, their hashed
+`InterUSS Platform USERNAME PASSWORD`.  So, if user `wing.com` had password `wing`, their hashed
 password would be SHA256(InterUSS Platform wing.com wing), which begins b03ed6.  To compute the
 SHA256 hash on a Linux command line:
 
@@ -89,7 +90,8 @@ which it was signed.
 
 ### Running
 
-To run a bare-HTTP InterUSS Platform auth server from the folder containing the resources above:
+To run a fully-functional InterUSS Platform auth server from the folder containing the resources
+above:
 
 ```shell
 export INTERUSS_AUTH_PATH=`pwd`
@@ -107,16 +109,4 @@ To make sure you have the latest versions, first run:
 ```shell
 docker pull interussplatform/auth_server
 docker pull interussplatform/auth_reverse_proxy
-```
-
-### Synchronized node
-
-To run a fully-functional non-production InterUSS Platform data node that
-synchronizes with a network of other InterUSS Platform data nodes:
-
-```shell
-export ZOO_MY_ID=[your InterUSS Platform network Zookeeper ID]
-export ZOO_SERVERS=[InterUSS Platform server network; ex: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888]
-export INTERUSS_PUBLIC_KEY=[paste public key here]
-docker-compose -p datanode up
 ```

--- a/authserver/docker/README.md
+++ b/authserver/docker/README.md
@@ -1,0 +1,122 @@
+# InterUSS Platform auth server Docker deployment
+
+## Introduction
+
+The contents of this folder enable the bring-up of a docker-compose system to
+host an InterUSS Platform auth server in a single command.
+
+## Contents
+
+### Dockerfile_authserver
+
+This Dockerfile builds an image containing the InterUSS Platform auth server serving via HTTP. It is
+insecure to use this auth server by itself because users authenticate with Basic authentication, so
+passwords are sent in the clear without an HTTPS wrapper.
+
+### Dockerfile_authreverseproxy
+
+This Dockerfile builds an image containing an nginx reverse proxy intended to
+gate requests to the provide HTTPS access to the auth server.
+
+### docker-compose.yaml
+
+This docker-compose configuration brings up an entire InterUSS Platform auth server in a single
+command.  By default, HTTPS access to the server is available on port 8121.
+
+## Running an auth server
+
+### Resources
+
+Before starting an auth server, a few resources must be generated.
+
+#### Access token key pair
+
+The auth server relies on encoding access tokens with a private key and publishing a public key with
+which others may validate them.  To generate this key pair, create a new folder and, in it:
+
+```shell
+openssl genrsa -out private.pem 2048
+openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+```
+
+Be careful never to share private.pem.
+
+#### Roster
+
+The core of the auth server is to translate user credentials into access tokens.  A roster defines
+the set of users, their passwords, and their respective scopes.  Create `roster.txt` in the same
+folder as the key pair above and populate it with one line per user.  Each line should consist of
+the user's username, their hashed password, and the scopes they are to be granted, each of those
+three fields separated by commas (and be careful to eliminate whitespace).  The scopes should be
+separated by spaces.  The hashed password is the SHA256 hash of
+"`InterUSS Platform USERNAME PASSWORD`".  So, if user `wing.com` had password `wing`, their hashed
+password would be SHA256(InterUSS Platform wing.com wing), which begins b03ed6.  To compute the
+SHA256 hash on a Linux command line:
+
+```shell
+echo -n "InterUSS Platform wing.com wing" | openssl dgst -sha256
+```
+
+Or, use an online SHA256 generator like https://www.xorbin.com/tools/sha256-hash-calculator, but
+this is less secure because the website may gain access to the password.
+
+When enrolling a user, it is best to have them choose their password and only send you their hashed
+password so the password itself is never stored in email servers.
+
+An example roster.txt may look like this:
+
+```
+wing.com,b03ed640ce1aed7f1dd9558c9312918b944496937e4fe81db1a3d9968a7ee1d0,interussplatform.com_operators.read interussplatform.com_operators.write
+otheruss.com,97b30e68738f0a7daebb94862da7baf4dbffa5913ac57b91ea33b33baee26573,interussplatform.com_operators.read interussplatform.com_operators.write
+```
+
+#### SSL certificate
+
+It does not make sense to run an auth server over HTTP, so SSL certificates must be provided.
+Ideally, these would come from a certificate authority, but a self-signed certificate can be
+generated with these commands:
+
+```shell
+mkdir certs
+mkdir private
+openssl req -x509 -newkey rsa:4096 -nodes -out certs/cert.pem -keyout private/key.pem -days 365
+```
+
+Note that self-signed certificates do not guarantee the identity of the remote
+host. To be fully secure, the certificate must be signed by a trusted
+certificate authority, and that certificate will only be valid on the host for
+which it was signed.
+
+### Running
+
+To run a bare-HTTP InterUSS Platform auth server from the folder containing the resources above:
+
+```shell
+export INTERUSS_AUTH_PATH=`pwd`
+export SSL_CERT_PATH=`pwd`/certs
+export SSL_KEY_PATH=`pwd`/private
+export INTERUSS_AUTH_ISSUER=yourdomain.com
+cd /path/to/this/folder
+docker-compose -p authserver up
+```
+
+To verify operation, navigate a browser to https://localhost:8121/status
+
+To make sure you have the latest versions, first run:
+
+```shell
+docker pull interussplatform/auth_server
+docker pull interussplatform/auth_reverse_proxy
+```
+
+### Synchronized node
+
+To run a fully-functional non-production InterUSS Platform data node that
+synchronizes with a network of other InterUSS Platform data nodes:
+
+```shell
+export ZOO_MY_ID=[your InterUSS Platform network Zookeeper ID]
+export ZOO_SERVERS=[InterUSS Platform server network; ex: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888]
+export INTERUSS_PUBLIC_KEY=[paste public key here]
+docker-compose -p datanode up
+```

--- a/authserver/docker/docker-compose.yaml
+++ b/authserver/docker/docker-compose.yaml
@@ -1,0 +1,65 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Brings up a full auth server instance.
+
+# Required environment variables:
+#   INTERUSS_AUTH_PATH: Path containing public.pem, private.pem, and roster.txt.
+#   SSL_CERT_PATH: Path to SSL certificate named cert.pem.
+#   SSL_KEY_PATH: Path to SSL private key named key.pem.
+
+# Optional environment variables:
+#   INTERUSS_AUTH_ISSUER: Text that will appear in 'iss' field of access_tokens (default
+#     interussplatform.com).
+#   INTERUSS_AUTH_PORT_HTTPS: Port on which to provide the InterUSS Platform auth server via HTTPS
+#     (default 8121).
+#   INTERUSS_AUTH_EXPIRATION: Number of seconds after issuance that access tokens will expire
+#     (default 3600).
+
+# To bring up this system:
+# docker-compose -p datanode up
+
+version: '3.6'
+
+services:
+
+  auth_server:
+    image: interussplatform/auth_server
+    expose:
+      - 5000
+    environment:
+      - INTERUSS_AUTH_SERVER=0.0.0.0
+      - INTERUSS_AUTH_PORT=5000
+      - INTERUSS_AUTH_VERBOSE=true
+      - INTERUSS_AUTH_ISSUER=${INTERUSS_AUTH_ISSUER:-interussplatform.com}
+      - INTERUSS_AUTH_EXPIRATION=${INTERUSS_AUTH_EXPIRATION:-3600}
+      - INTERUSS_AUTH_PUBLIC_KEY /resources/public.pem
+      - INTERUSS_AUTH_PRIVATE_KEY /resources/private.pem
+      - INTERUSS_AUTH_ROSTER /resources/roster.txt
+    volumes:
+      - ${INTERUSS_AUTH_PATH:?Environment variable INTERUSS_AUTH_PATH must be set}:/resources
+
+  reverse_proxy:
+    image: interussplatform/auth_reverse_proxy
+    ports:
+      - "${INTERUSS_AUTH_PORT_HTTPS:-8121}:${INTERUSS_AUTH_PORT_HTTPS:-8121}"
+    environment:
+      - INTERUSS_AUTH_PORT_HTTPS=${INTERUSS_AUTH_PORT_HTTPS:-8121}
+      - INTERUSS_AUTH_SERVER=auth_server
+      - INTERUSS_AUTH_PORT=5000
+    depends_on:
+      - auth_server
+    volumes:
+      - ${SSL_CERT_PATH:?Environment variable SSL_CERT_PATH must be set}:/etc/ssl/certs
+      - ${SSL_KEY_PATH:?Environment variable SSL_KEY_PATH must be set}:/etc/ssl/private

--- a/authserver/docker/nginx_entrypoint.sh
+++ b/authserver/docker/nginx_entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo nginx_entrypoint.sh started
+
+echo "
+
+  worker_processes 1;
+
+  events { worker_connections 1024; }
+
+  http {
+    upstream auth-server {
+      server $INTERUSS_AUTH_SERVER:$INTERUSS_AUTH_PORT;
+    }
+
+    underscores_in_headers on;
+
+    server {
+      listen ${INTERUSS_AUTH_PORT_HTTPS:-8121} ssl;
+      # server_name         www.example.com;
+      ssl_certificate     /etc/ssl/certs/cert.pem;
+      ssl_certificate_key /etc/ssl/private/key.pem;
+      ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+      ssl_ciphers         HIGH:!aNULL:!MD5;
+
+      location / {
+        proxy_pass         http://auth-server;
+      }
+    }
+  }
+
+" > /etc/nginx/nginx.conf
+
+echo === nginx.conf ===
+cat /etc/nginx/nginx.conf
+echo ==================
+
+echo Starting nginx...
+
+nginx -g "daemon off;"

--- a/authserver/src/auth_server.py
+++ b/authserver/src/auth_server.py
@@ -195,7 +195,8 @@ def ParseOptions(argv):
     dest='server',
     default=os.getenv(_KEY_SERVER, '127.0.0.1'),
     help='Specific server name to use on this machine for the web services '
-         '[or use env variable %s]' % _KEY_SERVER,
+         '(only applies directly from command line with Flask development '
+         'server) [or use env variable %s]' % _KEY_SERVER,
     metavar='SERVER')
   parser.add_option(
     '-p',
@@ -298,7 +299,7 @@ def _LoadConfiguration(options=None):
     reader = csv.reader(f)
     for line in reader:
       if len(line) == 3:
-        users[line[0]] = User(line[1], line[2])
+        users[line[0]] = User(line[1], line[2].split(' '))
 
   issuer = (options.issuer if options else
             os.environ.get(_KEY_ISSUER, '127.0.0.1'))

--- a/authserver/src/auth_server.py
+++ b/authserver/src/auth_server.py
@@ -1,0 +1,333 @@
+"""The InterUSS Platform authorization server.
+
+This module is an example of a server that can provide access tokens to access
+an InterUSS Platform data node.
+
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import collections
+import csv
+import datetime
+import hashlib
+import logging
+from optparse import OptionParser
+import os
+import sys
+import uuid
+from flask import abort
+from flask import Flask
+from flask import jsonify
+from flask import request
+import jwt
+from rest_framework import status
+
+VERSION = '0.1.0.000'  # Initial draft/demo release
+
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+log = logging.getLogger('InterUSS_AuthServer')
+webapp = Flask(__name__)  # Global object serving the authorization service
+
+
+config = None
+Configuration = collections.namedtuple(
+    'Configuration', 'public_key private_key users issuer expiration')
+
+
+_UNIX_EPOCH = datetime.datetime.utcfromtimestamp(0)
+_SALT = 'InterUSS Platform'
+
+
+# Environment variable names for various parameters:
+_KEY_SERVER = 'INTERUSS_AUTH_SERVER'
+_KEY_PORT = 'INTERUSS_AUTH_PORT'
+_KEY_VERBOSE = 'INTERUSS_AUTH_VERBOSE'
+_KEY_PUBLIC_KEY = 'INTERUSS_AUTH_PUBLIC_KEY'
+_KEY_PRIVATE_KEY = 'INTERUSS_AUTH_PRIVATE_KEY'
+_KEY_ROSTER = 'INTERUSS_AUTH_ROSTER'
+_KEY_ISSUER = 'INTERUSS_AUTH_ISSUER'
+_KEY_EXPIRATION = 'INTERUSS_AUTH_EXPIRATION'
+
+
+@webapp.route('/', methods=['GET'])
+@webapp.route('/status', methods=['GET'])
+def Status():
+  # Just a quick status checker.
+  log.debug('Status handler instantiated...')
+  return jsonify({
+    'status': 'success',
+    'message': 'OK',
+    'version': VERSION
+  })
+
+
+@webapp.route('/key', methods=['GET'])
+def WebKey():
+  # Returns the public key that may be used to validate tokens from this server.
+  log.debug('Key handler instantiated...')
+  return config.public_key
+
+
+@webapp.route(
+  '/oauth/token',
+  methods=['POST'])
+def TokenHandler():
+  """Handles the web service request for an access token.
+
+  Tokens can be manually validated at https://jwt.io
+
+  Args:
+    Basic Authorization header.
+    Query argument of grant_type must be "client_credentials".
+  Returns:
+    200 with token and associated data in JSON format, or the nominal error
+    codes as necessary.
+  """
+  log.debug('Token handler instantiated...')
+
+  # Verify grant_type
+  if 'grant_type' not in request.args and 'grant_type' not in request.form:
+    abort(status.HTTP_400_BAD_REQUEST, jsonify({
+      "error": "invalid_request",
+      "error_description": "Missing grant type"
+    }))
+
+  grant_type = (request.args['grant_type'] if 'grant_type' in request.args
+                else request.form['grant_type'])
+  if grant_type != 'client_credentials':
+    abort(status.HTTP_400_BAD_REQUEST, jsonify({
+      "error": "unsupported_grant_type",
+      "error_description": "Unsupported grant type: " + grant_type
+    }))
+
+  # Authorize user
+  auth = request.authorization
+  if not auth:
+    abort(status.HTTP_401_UNAUTHORIZED, jsonify({
+      "error": "authorization_header_missing",
+      "error_description": 'Authorization header missing'
+    }))
+
+  if auth.username not in config.users:
+    abort(status.HTTP_401_UNAUTHORIZED, jsonify({
+      "error": "invalid_login",
+      "error_description": 'Username or password not recognized'
+    }))
+  user = config.users[auth.username]
+
+  password_hash = hashlib.sha256(
+    _SALT + ' ' + auth.username + ' ' + auth.password).hexdigest()
+  if password_hash != user.hashed_password:
+    abort(status.HTTP_401_UNAUTHORIZED, jsonify({
+      "error": "invalid_login",
+      "error_description": 'Username or password not recognized'
+    }))
+
+  # Create access_token
+  timestamp = int((datetime.datetime.utcnow() - _UNIX_EPOCH).total_seconds())
+  jti = str(uuid.uuid4())
+
+  payload = {
+    'sub': auth.username,
+    'nbf': timestamp,
+    'scope': user.scopes,
+    'iss': config.issuer,
+    'exp': timestamp + config.expiration,
+    'jti': jti,
+    'client_id': auth.username,
+  }
+
+  access_token = jwt.encode(payload, key=config.private_key, algorithm='RS256')
+
+  # Make sure the token validates correctly
+  try:
+    jwt.decode(access_token, config.public_key, algorithms='RS256')
+  except jwt.ExpiredSignatureError as e:
+    log.error('Generated access token has already expired: ' + str(e))
+    abort(status.HTTP_500_INTERNAL_SERVER_ERROR,
+          'Encountered ExpiredSignatureError when validating generated token')
+  except jwt.DecodeError as e:
+    log.error('Generated access token could not be decoded: ' + str(e))
+    abort(status.HTTP_500_INTERNAL_SERVER_ERROR,
+          'Generated access token could not be decoded for validation')
+
+  return jsonify({
+    'access_token': access_token,
+    'token_type': "bearer",
+    'expires_in': config.expiration - 1,
+    'scope': ' '.join(payload['scope']),
+    'sub': payload['sub'],
+    'nbf': payload['nbf'],
+    'iss': payload['iss'],
+    'jti': payload['jti'],
+  })
+
+
+def ParseOptions(argv):
+  """Parses desired options from the command line.
+
+  Uses the command line parameters as argv, which can be altered as needed for
+  testing.
+
+  Args:
+    argv: Command line parameters
+  Returns:
+    Options structure
+  """
+  parser = OptionParser(
+    usage='usage: %prog [options]', version='%prog ' + VERSION)
+  parser.add_option(
+    '-s',
+    '--server',
+    dest='server',
+    default=os.getenv(_KEY_SERVER, '127.0.0.1'),
+    help='Specific server name to use on this machine for the web services '
+         '[or use env variable %s]' % _KEY_SERVER,
+    metavar='SERVER')
+  parser.add_option(
+    '-p',
+    '--port',
+    dest='port',
+    default=os.getenv(_KEY_PORT, '80'),
+    help='Specific port to use on this machine for the web services '
+         '[or use env variable %s]' % _KEY_PORT,
+    metavar='PORT')
+  parser.add_option(
+    '-v',
+    '--verbose',
+    action='store_true',
+    dest='verbose',
+    default=os.getenv(_KEY_VERBOSE, False),
+    help='Verbose (DEBUG) logging [or env variable %s]' % _KEY_VERBOSE)
+  parser.add_option(
+    '-d',
+    '--publickey',
+    dest='publickey',
+    default=os.getenv(_KEY_PUBLIC_KEY, None),
+    help='Name of file containing public key for JWT verification. Given an '
+         'existing private key, generate a public key with '
+         '`openssl rsa -in private.pem -outform PEM -pubout -out public.pem` '
+         '[or use env variable %s]' % _KEY_PUBLIC_KEY,
+    metavar='FILENAME')
+  parser.add_option(
+    '-k',
+    '--privatekey',
+    dest='privatekey',
+    default=os.getenv(_KEY_PRIVATE_KEY, None),
+    help='Name of file containing private key for JWT generation. Generate one '
+         'with `openssl genrsa -out private.pem 2048` '
+         '[or use env variable %s]' % _KEY_PRIVATE_KEY,
+    metavar='FILENAME')
+  parser.add_option(
+    '-r',
+    '--roster',
+    dest='roster',
+    default=os.getenv(_KEY_ROSTER, None),
+    help='Name of file containing lines of\nUSERNAME,HASHED PASSWORD,SCOPES\n'
+         'where USERNAME is the domain name of the user, HASHED PASSWORD is '
+         '(the SHA256 hash of "InterUSS Platform USERNAME PASSWORD" (so, for '
+         'instance, if wing.com\'s password were "wing", its HASHED PASSWORD '
+         'would be SHA256(InterUSS Platform wing.com wing) which begins '
+         'b03ed6. Generate this hash at a Linux command line with `echo -n '
+         '"InterUSS Platform wing.com wing" | openssl dgst -sha256` Scopes '
+         'should be separated by spaces [or use env variable %s]' % _KEY_ROSTER,
+    metavar='FILENAME')
+  parser.add_option(
+    '-i',
+    '--issuer',
+    dest='issuer',
+    default=os.getenv(_KEY_ISSUER, '127.0.0.1'),
+    help='What to populate in the JWT iss (issuer) field '
+         '[or env variable %s]' % _KEY_ISSUER,
+    metavar='ISSUER')
+  parser.add_option(
+    '-e',
+    '--expiration',
+    dest='expiration',
+    default=os.getenv(_KEY_EXPIRATION, '3600'),
+    help='Number of seconds each access_token should live for '
+         '[or env variable %s]' % _KEY_EXPIRATION,
+    metavar='SECONDS')
+  (options, args) = parser.parse_args(argv)
+  del args
+  return options
+
+
+def _LoadConfiguration(options=None):
+  """Initializes the configuration of this server.
+
+  The side effect of this method is to set the global variable 'config'.
+
+  Args:
+    options: Options structure with a field per option.
+  """
+  global config
+  if (options and options.verbose) or os.environ.get(_KEY_VERBOSE):
+    log.setLevel(logging.DEBUG)
+  log.debug('Initializing InterUSS auth server...')
+
+  filename = (options.publickey if options else
+              os.environ.get(_KEY_PUBLIC_KEY, None))
+  if filename:
+    with open(filename, 'r') as f:
+      public_key = f.read()
+  else:
+    public_key = None
+
+  filename = options.privatekey if options else os.environ[_KEY_PRIVATE_KEY]
+  with open(filename, 'r') as f:
+    private_key = f.read()
+
+  filename = options.roster if options else os.environ[_KEY_ROSTER]
+  users = {}
+  User = collections.namedtuple('User', 'hashed_password scopes')
+  with open(filename, 'r') as f:
+    reader = csv.reader(f)
+    for line in reader:
+      if len(line) == 3:
+        users[line[0]] = User(line[1], line[2])
+
+  issuer = (options.issuer if options else
+            os.environ.get(_KEY_ISSUER, '127.0.0.1'))
+
+  expiration = int(options.expiration if options else
+                   os.environ.get(_KEY_EXPIRATION, '3600'))
+
+  config = Configuration(public_key, private_key, users, issuer, expiration)
+
+
+@webapp.before_first_request
+def BeforeFirstRequest():
+  if config is None:
+    # This is triggered when using a separate WSGI server (e.g., Gunicorn).
+    _LoadConfiguration()
+
+
+def main(argv):
+  # This is only triggered when run as a standalone app using Flask's debug
+  # WSGI server.
+  log.debug(
+    """Instantiated application, parsing commandline
+  %s and initializing connection...""", str(argv))
+  options = ParseOptions(argv)
+  _LoadConfiguration(options)
+  log.info('Starting webserver...')
+  webapp.run(host=options.server, port=int(options.port))
+
+
+# This is what starts everything when run directly as an executable
+if __name__ == '__main__':
+  main(sys.argv)

--- a/authserver/src/auth_server.py
+++ b/authserver/src/auth_server.py
@@ -142,7 +142,7 @@ def TokenHandler():
 
   payload = {
     'sub': auth.username,
-    'nbf': timestamp,
+    'nbf': timestamp - 1,
     'scope': user.scopes,
     'iss': config.issuer,
     'exp': timestamp + config.expiration,

--- a/authserver/src/auth_server_test.py
+++ b/authserver/src/auth_server_test.py
@@ -1,0 +1,143 @@
+"""Test of the InterUSS Platform auth server.
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from datetime import datetime
+import hashlib
+import json
+import jwt
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+
+import requests
+
+
+# Note that openssl must be installed on the system to use this test.
+
+
+BASE_URL = 'http://127.0.0.1:8210'
+
+
+class InterUSSAuthServerTestCase(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    cls.path = tempfile.mkdtemp()
+
+    private_key_file = os.path.join(cls.path, 'private.pem')
+    subprocess.call(
+      ('openssl genrsa -out %s 2048' % private_key_file).split(' '))
+
+    public_key_file = os.path.join(cls.path, 'public.pem')
+    subprocess.call(
+      ('openssl rsa -in %s -outform PEM -pubout -out %s'
+       % (private_key_file, public_key_file)).split(' '))
+
+    roster_file = os.path.join(cls.path, 'roster.txt')
+    cls.users = {
+      'myuss.com': 'uss',
+      'other.com': 'other',
+    }
+    scopes = ' '.join(('interussplatform.com_operators.read',
+                       'interussplatform.com_operators.write'))
+    with open(roster_file, 'w') as f:
+      for username, password in cls.users.items():
+        password_hash = hashlib.sha256(
+          'InterUSS Platform %s %s' % (username, password)).hexdigest()
+        f.write(','.join((username, password_hash, scopes)) + '\n')
+
+    os.environ['INTERUSS_AUTH_SERVER'] = '127.0.0.1'
+    os.environ['INTERUSS_AUTH_PORT'] = '8210'
+    os.environ['INTERUSS_AUTH_VERBOSE'] = 'true'
+    os.environ['INTERUSS_AUTH_PUBLIC_KEY'] = public_key_file
+    os.environ['INTERUSS_AUTH_PRIVATE_KEY'] = private_key_file
+    os.environ['INTERUSS_AUTH_ROSTER'] = roster_file
+    os.environ['INTERUSS_AUTH_ISSUER'] = 'issuer.com'
+    os.environ['INTERUSS_AUTH_EXPIRATION'] = '2'
+
+    cls.app = subprocess.Popen('exec python auth_server.py', shell=True)
+    time.sleep(1)
+
+  @classmethod
+  def tearDownClass(cls):
+    cls.app.kill()
+    shutil.rmtree(cls.path)
+
+  def testStatus(self):
+    result = requests.get(BASE_URL + '/status')
+    self.assertEqual(200, result.status_code)
+    self.assertIn(b'OK', result.content)
+    result = requests.get(BASE_URL)
+    self.assertEqual(200, result.status_code)
+    self.assertIn(b'OK', result.content)
+
+  def testGetKey(self):
+    result = requests.get(BASE_URL + '/key')
+    self.assertEqual(200, result.status_code)
+    self.assertIn(b'PUBLIC KEY', result.content)
+
+  def testMissingAuthorization(self):
+    result = requests.post(BASE_URL + '/oauth/token',
+                           {'grant_type': 'client_credentials'})
+    self.assertEqual(401, result.status_code)
+
+  def testBadAuthorization(self):
+    result = requests.post(BASE_URL + '/oauth/token',
+                           {'grant_type': 'client_credentials'},
+                           auth=('myuss.com', 'wrong'))
+    self.assertEqual(401, result.status_code)
+
+    result = requests.post(BASE_URL + '/oauth/token',
+                           {'grant_type': 'client_credentials'},
+                           auth=('nonexistent', 'uss'))
+    self.assertEqual(401, result.status_code)
+
+  def testMissingGrantType(self):
+    result = requests.post(BASE_URL + '/oauth/token', auth=('myuss.com', 'uss'))
+    self.assertEqual(400, result.status_code)
+
+  def testNormalUsage(self):
+    result = requests.post(BASE_URL + '/oauth/token',
+                           {'grant_type': 'client_credentials'},
+                           auth=('myuss.com', 'uss'))
+    self.assertEqual(200, result.status_code)
+    jresult = json.loads(result.content)
+    access_token = jresult['access_token']
+
+    result = requests.get(BASE_URL + '/key')
+    self.assertEqual(200, result.status_code)
+    public_key = result.content
+
+    r = jwt.decode(access_token, public_key, algorithms='RS256')
+    self.assertEqual('myuss.com', r['client_id'])
+    now_timestamp = int(
+      (datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds())
+    self.assertGreater(r['exp'], now_timestamp)
+    self.assertItemsEqual(r['scope'].split(' '),
+                          ('interussplatform.com_operators.read',
+                           'interussplatform.com_operators.write'))
+
+    time.sleep(3)
+    self.assertRaises(jwt.ExpiredSignatureError,
+                      lambda: jwt.decode(
+                          access_token, public_key, algorithms='RS256'))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/authserver/src/auth_server_test.py
+++ b/authserver/src/auth_server_test.py
@@ -129,7 +129,7 @@ class InterUSSAuthServerTestCase(unittest.TestCase):
     now_timestamp = int(
       (datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds())
     self.assertGreater(r['exp'], now_timestamp)
-    self.assertItemsEqual(r['scope'].split(' '),
+    self.assertItemsEqual(r['scope'],
                           ('interussplatform.com_operators.read',
                            'interussplatform.com_operators.write'))
 


### PR DESCRIPTION
This PR adds a simple authorization server that generates access tokens to be used to access an InterUSS Platform data node.  The server itself (```auth_server.py```) uses a private key to generate a JWT access token for a user from a provided roster of (username, hashed password, scopes) after authorizing with Basic authorization, as well as serving the public key.  All transactions are over HTTP which makes the bare server unsuitable for standalone use; instead, a docker-compose system adds an nginx reverse proxy in front of the auth server to wrap all transport in HTTPS.

This version grants all available scopes, ignoring whatever scopes may have been requested.  A future version will grant only the requested scope(s).