### PR TITLE
Update UVR schema and validate required fields

### DIFF
--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -345,13 +345,16 @@ def UvrDataHandler(zoom, message_id):
       'message': 'uvr data must be provided in the request body'})
 
   result = {}
-  unvalidated_uvr['originator_id'] = uss_id
   try:
     uvr = uvrs.Uvr(unvalidated_uvr)
 
     if uvr['message_id'] != message_id:
       raise ValueError('message_id "%s" in request does not match message_id '
                        '"%s" in UVR' % (message_id, uvr['message_id']))
+    if uvr['uss_name'] != uss_id:
+      abort(status.HTTP_403_FORBIDDEN,
+            'uss_name "%s" in UVR does not match uss_id "%s" in access token' %
+            (uvr['uss_name'], uss_id))
 
     zoom = int(zoom)
     tiles = uvr.get_tiles(zoom)

--- a/datanode/src/storage_api_test.py
+++ b/datanode/src/storage_api_test.py
@@ -933,7 +933,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
       headers={'access_token': uss_id}
     ).status_code)
 
-    self.assertEqual(403, self.app.put(
+    self.assertEqual(400, self.app.put(
       '/UVR/%d/%s' % (zoom, message_id),
       data=uvr_json,
       headers={'access_token': 'wrong'}
@@ -952,6 +952,14 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
       headers={'access_token': uss_id}
     ).status_code)
 
+    uvr_mismatched_uss = copy.deepcopy(uvr)
+    uvr_mismatched_uss._core['uss_name'] = 'otheruss'
+    self.assertEqual(403, self.app.put(
+      '/UVR/%d/%s' % (zoom, message_id),
+      json=uvr_mismatched_uss.to_json(),
+      headers={'access_token': uss_id}
+    ).status_code)
+
     verify_uvr_count(uvr, 0)
 
     # Correctly emplace a UVR and verify its presence
@@ -964,7 +972,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
 
     # Try to delete the UVR as a different USS
     storage_api.TESTID = 'uss2'
-    self.assertEqual(400, self.app.delete(
+    self.assertEqual(403, self.app.delete(
       '/UVR/%d/%s' % (zoom, message_id),
       data=uvr_json,
       headers={'access_token': 'uss2'}
@@ -981,7 +989,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
     verify_uvr_count(uvr, 1)
 
     bad_uvr = copy.deepcopy(uvr)
-    bad_uvr._core['origin'] = 'FIMS'
+    bad_uvr._core['reason'] = 'different'
     self.assertEqual(400, self.app.delete(
       '/UVR/%d/%s' % (zoom, message_id),
       json=bad_uvr.to_json(),

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -535,7 +535,7 @@ class USSMetadataManager(object):
       JSend formatted response (https://labs.omniti.com/labs/jsend)
     """
     log.debug('Setting UVR %s in %d grid cells for %s...',
-              uvr['message_id'], len(grids), uvr['originator_id'])
+              uvr['message_id'], len(grids), uvr['uss_name'])
     try:
       # Get and update USSMetadata for all affected cells in memory
       contents = []
@@ -640,7 +640,7 @@ class USSMetadataManager(object):
       JSend formatted response (https://labs.omniti.com/labs/jsend)
     """
     log.debug('Deleting UVR %s in %d grid cells for %s...',
-              uvr['message_id'], len(grids), uvr['originator_id'])
+              uvr['message_id'], len(grids), uvr['uss_name'])
     try:
       status = 200
       for _ in range(DELETE_ATTEMPTS):

--- a/datanode/src/test_utils.py
+++ b/datanode/src/test_utils.py
@@ -51,8 +51,7 @@ def make_uvr(uss_id, message_id=None, coords=None):
     coords = [[-92.1, 36.5], [-91.9, 36.5], [-92.1, 36.55], [-92.1, 36.5]]
   return uvrs.Uvr({
     'message_id': message_id,
-    'origin': 'USS',
-    'originator_id': uss_id,
+    'uss_name': uss_id,
     'type': 'DYNAMIC_RESTRICTION',
     'cause': 'SAFETY',
     'geography': {


### PR DESCRIPTION
This PR updates the UVR schema to remove `origin` and `originator_id` and add `uss_name` according to [this link](https://github.com/nasa/utm-apis/blob/0435188d755c6685c75c10eb82ce0164a7e6a51f/utm-domains/utm-domain-commons.yaml#L1476).  It also adds validation to ensure that all required UVR fields (including `uss_name`) are specified, and then checks whether the `uss_name` provided in the UVR matches the ID in the access token (instead of overwriting `originator_id` with the ID in the access token).

Also, OTHER is added to `cause` enum values, and additional validation is added to `permitted_uas`.