### PR TITLE
Fix backwards compatibility for UVRs on storage side only

### DIFF
--- a/assets/swaggerhub_api.yaml
+++ b/assets/swaggerhub_api.yaml
@@ -1092,6 +1092,7 @@ definitions:
     description: >-
       An area limiting UAS access
     required:
+      - uss_name
       - message_id
       - cause
       - geography
@@ -1100,19 +1101,12 @@ definitions:
       - effective_time_begin
       - effective_time_end
       - permitted_uas
-      - permitted_gufis
     properties:
       message_id:
         $ref: '#/definitions/uuid'
-      origin:
-        description: The entity that generated this message
-        type: string
-        enum:
-          - FIMS
-          - USS
-      originator_id:
+      uss_name:
         description: >-
-          The uss_id of the enacting USS, provided via the access token
+          The uss_id of the enacting USS, must match ID in the access token
         type: string
         minLength: 4
         exclusiveMinimum: false
@@ -1197,8 +1191,7 @@ definitions:
         maxLength: 1000
     example:
       message_id: '00000000-0000-4444-8888-000000000000'
-      origin: USS
-      originator_id: 'tcl4box-uss1.com'
+      uss_name: 'tcl4box-uss1.com'
       type: DYNAMIC_RESTRICTION
       cause: SAFETY
       geography:

--- a/datanode/docker/Dockerfile_storageapi
+++ b/datanode/docker/Dockerfile_storageapi
@@ -16,6 +16,7 @@
 
 # To build an image from this Dockerfile:
 # docker image build -f Dockerfile_storageapi -t interussplatform/storage_api:tcl4 ../src
+# docker tag interussplatform/storage_api:tcl4 interussplatform/storage_api:tcl4.1.0.011
 
 # To run this image:
 # docker run \

--- a/datanode/docker/README.md
+++ b/datanode/docker/README.md
@@ -98,7 +98,31 @@ synchronizes with a network of other InterUSS Platform data nodes:
 export ZOO_MY_ID=[your InterUSS Platform network Zookeeper ID]
 export ZOO_SERVERS=[InterUSS Platform server network; ex: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888, make sure your server is 0.0.0.0]
 export INTERUSS_PUBLIC_KEY=[paste public key here]
+export SSL_CERT_PATH=[/path/containing/cert.pem/in/it]
+export SSL_KEY_PATH=[/path/containing/key.pem/in/it]
+docker-compose -f docker-compose.yaml -f docker-compose_localssl.yaml -p datanode up
+```
 
+### Prerequisites
+The above instructions assume that both `docker` and `docker-compose` are present on your system.
+
+#### docker
+To install `docker`, download and run a single script from get.docker.com described
+[here](https://github.com/docker/docker-install#usage), or follow the instructions
+[here](https://docs.docker.com/install/).
+
+#### docker-compose
+To install `docker-compose`, just download and mark
+executable a single file as described
+[here](https://docs.docker.com/compose/install/#install-compose).
+
+### No docker-compose
+If it is absolutely impossible to install docker-compose on your machine, the
+following commands may work to bring up a system (but they may easily be out
+of date; see docker-compose.yaml and docker-compose_localssl.yaml for the most
+up-to-date system configuration information):
+
+```shell
 docker run --name="tcl4-zookeeper" --restart always -p 2888:2888 -p 3888:3888 --expose 2181 -e ZOO_MY_ID="${ZOO_MY_ID}" -e ZOO_SERVERS="${ZOO_SERVERS}" -d zookeeper
 
 docker run --name="tcl4-storage_api" --link="tcl4-zookeeper" --restart always --expose 5000 -e INTERUSS_API_PORT=5000 -e INTERUSS_PUBLIC_KEY="${INTERUSS_PUBLIC_KEY}" -e INTERUSS_CONNECTIONSTRING="tcl4-zookeeper:2181" -e INTERUSS_VERBOSE=true -d interussplatform/storage_api:tcl4

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -90,7 +90,8 @@ import uvrs
 # VERSION = 'TCL4.0.1.007'  # Fixed non-tz aware dates and version in operations
 # VERSION = 'TCL4.0.2.008'  # sync with master branch for multi-grid and docker updates
 # VERSION = 'TCL4.0.3.009'  # Added support for UVRs
-VERSION = 'TCL4.0.3.010'  # Fixed backwards compatibility issue
+# VERSION = 'TCL4.0.3.010'  # Fixed backwards compatibility issue
+VERSION = 'TCL4.1.0.011'  # Updated UVR schema (not API-compatible with previous UVR schema)
 
 # Initialize everything we need
 TESTID = None

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -724,8 +724,8 @@ class USSMetadataManager(object):
     path = '%s/%s/%s/%s/%s' % (GRID_PATH, str(z), str(x), str(y),
                                USS_METADATA_FILE)
     try:
-      log.debug('Setting metadata to %s...', str(m))
-      self.zk.set(path, json.dumps(m.to_json()), version)
+      log.debug('Setting metadata to %s...', str(m.to_json(True)))
+      self.zk.set(path, json.dumps(m.to_json(True)), version)
       status = 200
     except BadVersionError:
       log.error('Sync token updated before write for %s...', path)
@@ -814,7 +814,7 @@ class USSMetadataManager(object):
       log.debug('Starting transaction to write all grids at once...')
       t = self.zk.transaction()
       for path, m, version in contents:
-        t.set_data(path, json.dumps(m.to_json()), version)
+        t.set_data(path, json.dumps(m.to_json(True)), version)
       log.debug('Committing transaction...')
       results = t.commit()
       if isinstance(results[0], RolledBackError):
@@ -894,7 +894,7 @@ class USSMetadataManager(object):
     log.debug('Starting transaction to write all grids at once...')
     t = self.zk.transaction()
     for path, m, version in contents:
-      t.set_data(path, json.dumps(m.to_json()), version)
+      t.set_data(path, json.dumps(m.to_json(True)), version)
     log.debug('Committing transaction...')
     results = t.commit()
     if isinstance(results[0], RolledBackError):

--- a/datanode/src/uss_metadata.py
+++ b/datanode/src/uss_metadata.py
@@ -76,8 +76,7 @@ class USSMetadata(object):
     uvrs: [
       {
         message_id: <uuid>
-        origin: <FIMS|USS>
-        originator_id: <uss_name or originator domain name>
+        uss_name: <USS ID matching access token>
         type: <DYNAMIC_RESTRICTION|STATIC_ADVISORY>
         cause: <WEATHER|ATC|SECURITY|SAFETY|MUNICIPALITY>
         geography:
@@ -103,14 +102,19 @@ class USSMetadata(object):
   """
 
   def __init__(self, content=None):
-    # Parse the metadata or create a new one if none
+    """Parse metadata in storage format or create a new one if no content.
+
+    Args:
+      content: String containing JSON dict with metadata information.
+    """
+    #
     if content:
       m = json.loads(content)
       self.version = m['version']
       self.timestamp = m['timestamp']
       self.operators = m['operators']
       if 'uvrs' in m:
-        self.uvrs = [uvrs.Uvr(j) for j in m['uvrs']]
+        self.uvrs = [uvrs.Uvr(j, True) for j in m['uvrs']]
       else:
         self.uvrs = []
     else:
@@ -155,12 +159,21 @@ class USSMetadata(object):
     else:
       return self.__add__(other)
 
-  def to_json(self):
+  def to_json(self, storage=False):
+    """Convert this USSMetadata object into a plain JSON dict.
+
+    Args:
+      storage: If True, return a JSON dict suitable for internal grid storage.
+        Otherwise, return an API-compatible JSON dict.
+
+    Returns:
+      JSON dict with content from this USSMetadata object.
+    """
     return {
       'version': self.version,
       'timestamp': self.timestamp,
       'operators': self.operators,
-      'uvrs': [uvr.to_json() for uvr in self.uvrs]
+      'uvrs': [uvr.to_json(storage) for uvr in self.uvrs]
     }
 
   def upsert_operator(self, uss_id, baseurl, announce,


### PR DESCRIPTION
This PR modifies the updated UVR schema behavior to store in the legacy format (so older clients/grid data aren't confused), but expose the new format in the API.  It also updates deployment instructions and the version tag.