### PR TITLE
Add deployment tools

### DIFF
--- a/authserver/docker/docker-compose.yaml
+++ b/authserver/docker/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       - INTERUSS_AUTH_ROSTER /resources/roster.txt
     volumes:
       - ${INTERUSS_AUTH_PATH:?Environment variable INTERUSS_AUTH_PATH must be set}:/resources
+    restart: always
 
   reverse_proxy:
     image: interussplatform/auth_reverse_proxy
@@ -65,3 +66,4 @@ services:
     volumes:
       - ${SSL_CERT_PATH:?Environment variable SSL_CERT_PATH must be set}:/etc/ssl/certs
       - ${SSL_KEY_PATH:?Environment variable SSL_KEY_PATH must be set}:/etc/ssl/private
+    restart: always

--- a/authserver/docker/node.sh
+++ b/authserver/docker/node.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file may be adapted to bring up or down a production auth server in one
+# command. Replace content in ** ** characters with your server-specific
+# information, and see README.md for more information.
+
+if [ "$1" == "" ]; then
+  echo "You must specify a command ('up' or 'down')"
+  exit 0
+fi
+
+wget -N https://raw.githubusercontent.com/wing-aviation/InterUSS-Platform/publicportal/authserver/docker/docker-compose.yaml
+export INTERUSS_AUTH_PATH=**FULL LOCAL PATH CONTAINING roster.txt, public.pem, and private.pem**
+export SSL_CERT_PATH=**FULL LOCAL PATH CONTAINING SSL CERTIFICATE**
+export SSL_KEY_PATH=**FULL LOCAL PATH CONTAINING SSL CERTIFICATE KEY**
+export SSL_CERT_NAME=**NAME OF SSL CERTIFICATE FILE (e.g., cert.crt or cert.chained.pem)**
+export SSL_KEY_NAME=**NAME OF SSL KEY FILE (e.g., private.pem or cert.key)**
+export INTERUSS_AUTH_ISSUER=**YOUR ISSUING DOMAIN NAME (e.g., auth.staging.interussplatform.com)**
+if [ "$1" == "up" ]; then
+  docker-compose -p authserver up -d
+else
+  docker-compose -p authserver down
+fi

--- a/datanode/docker/docker-compose.yaml
+++ b/datanode/docker/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - ZOO_MY_ID=${ZOO_MY_ID:-1}
       - ZOO_SERVERS=${ZOO_SERVERS:-server.1=0.0.0.0:2888:3888}
+    restart: always
 
   storage_api:
     image: interussplatform/storage_api:publicportal
@@ -62,6 +63,7 @@ services:
       - INTERUSS_TESTID=${INTERUSS_TESTID:-}
     depends_on:
       - zoo
+    restart: always
 
   reverse_proxy:
     image: interussplatform/reverse_proxy
@@ -77,3 +79,4 @@ services:
       - SSL_KEY_NAME
     depends_on:
       - storage_api
+    restart: always

--- a/datanode/docker/node.sh
+++ b/datanode/docker/node.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file may be adapted to bring up or down a production node in one
+# command. Replace content in ** ** characters with your server-specific
+# information, and see README.md for more information.
+
+if [ "$1" == "" ]; then
+  echo "You must specify a command ('up' or 'down')"
+  exit 0
+fi
+
+wget -N https://raw.githubusercontent.com/wing-aviation/InterUSS-Platform/publicportal/datanode/docker/docker-compose.yaml
+wget -N https://raw.githubusercontent.com/wing-aviation/InterUSS-Platform/publicportal/datanode/docker/docker-compose_localssl.yaml
+wget -N https://**YOUR AUTH SERVER (e.g., auth.staging.interussplatform.com:8121)**/key
+export SSL_CERT_PATH=**FULL LOCAL PATH CONTAINING SSL CERTIFICATE**
+export SSL_KEY_PATH=**FULL LOCAL PATH CONTAINING SSL CERTIFICATE KEY**
+export SSL_CERT_NAME=**NAME OF SSL CERTIFICATE FILE (e.g., cert.crt or cert.chained.pem)**
+export SSL_KEY_NAME=**NAME OF SSL KEY FILE (e.g., private.pem or cert.key)**
+export ZOO_MY_ID=1
+export ZOO_SERVERS=0.0.0.0:2888:3888
+export INTERUSS_PUBLIC_KEY="`cat key`"
+if [ "$1" == "up" ]; then
+  docker-compose -f docker-compose.yaml -f docker-compose_localssl.yaml -p datanode up -d
+else
+  docker-compose -f docker-compose.yaml -f docker-compose_localssl.yaml -p datanode down
+fi


### PR DESCRIPTION
This PR adds `node.sh` scripts for both the auth server and data node that, after being filled in with server-specific information, can be used to bring up or down the respective production system in one command.  It also adds `restart: always` to make the docker containers more resilient.