### PR TITLE
Update TCL4 deployment information

### DIFF
--- a/datanode/docker/Dockerfile_reverseproxy
+++ b/datanode/docker/Dockerfile_reverseproxy
@@ -29,6 +29,8 @@
 # Optional environment variables:
 #   INTERUSS_API_PORT_HTTP: Port on which the InterUSS API will be served via HTTP (default 8120).
 #   INTERUSS_API_PORT_HTTPS: Port on which the InterUSS API will be served via HTTPS (default 8121).
+#   SSL_CERT_NAME: File name of SSL certificate (default: cert.pem)
+#   SSL_KEY_NAME: File name of SSL private key (default: key.pem)
 
 FROM nginx
 

--- a/datanode/docker/README.md
+++ b/datanode/docker/README.md
@@ -36,19 +36,19 @@ By layering this docker-compose configuration on top of docker-compose.yaml,
 users may provide their own SSL certificates. This is the intended usage in
 production.
 
-## Usage
+## Test Usage
 
-### Stand-alone test node
-
-To run a stand-alone test InterUSS Platform data node that does not synchronize
-with any other data nodes:
+## Stand-alone sandbox
+To run a stand-alone test InterUSS Platform data node that does not require
+authorization or synchronize with any other data nodes:
 
 ```shell
-export INTERUSS_PUBLIC_KEY=test
+export INTERUSS_TESTID=sandbox
+export INTERUSS_PUBLIC_KEY=none
 docker-compose -p datanode up
 ```
 
-To verify operation, navigate a browser to http://localhost:8120/status
+To verify operation, navigate a browser to https://localhost:8121/status
 
 To make sure you have the latest versions, first run:
 
@@ -70,7 +70,7 @@ export INTERUSS_PUBLIC_KEY=[paste public key here]
 docker-compose -p datanode up
 ```
 
-## SSL
+### SSL
 
 By default, the data node docker-compose configuration will serve HTTPS
 requests on port 8121 using a test self-signed certificate included in this
@@ -94,6 +94,18 @@ which it was signed.
 To run a fully-functional production InterUSS Platform data node that
 synchronizes with a network of other InterUSS Platform data nodes:
 
+### With node.sh
+Copy `node.sh` to your server, supply the necessary certificates, and edit
+`node.sh` to fill in the appropriate variable values.  Then run
+
+```shell
+sh node.sh N
+```
+
+...where N is the node index of the InterUSS Platform network the server is
+participating in.
+
+### With docker-compose
 ```shell
 export ZOO_MY_ID=[your InterUSS Platform network Zookeeper ID]
 export ZOO_SERVERS=[InterUSS Platform server network; ex: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888, make sure your server is 0.0.0.0]
@@ -103,20 +115,20 @@ export SSL_KEY_PATH=[/path/containing/key.pem/in/it]
 docker-compose -f docker-compose.yaml -f docker-compose_localssl.yaml -p datanode up
 ```
 
-### Prerequisites
+#### Prerequisites
 The above instructions assume that both `docker` and `docker-compose` are present on your system.
 
-#### docker
+##### docker
 To install `docker`, download and run a single script from get.docker.com described
 [here](https://github.com/docker/docker-install#usage), or follow the instructions
 [here](https://docs.docker.com/install/).
 
-#### docker-compose
+##### docker-compose
 To install `docker-compose`, just download and mark
 executable a single file as described
 [here](https://docs.docker.com/compose/install/#install-compose).
 
-### No docker-compose
+### Manually
 If it is absolutely impossible to install docker-compose on your machine, the
 following commands may work to bring up a system (but they may easily be out
 of date; see docker-compose.yaml and docker-compose_localssl.yaml for the most

--- a/datanode/docker/docker-compose.yaml
+++ b/datanode/docker/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
     environment:
       - ZOO_MY_ID=${ZOO_MY_ID:-1}
       - ZOO_SERVERS=${ZOO_SERVERS:-server.1=0.0.0.0:2888:3888}
+    restart: always
 
   storage_api:
     image: interussplatform/storage_api:tcl4
@@ -62,6 +63,7 @@ services:
       - INTERUSS_TESTID=${INTERUSS_TESTID:-}
     depends_on:
       - zoo
+    restart: always
 
   reverse_proxy:
     image: interussplatform/reverse_proxy
@@ -73,5 +75,8 @@ services:
       - INTERUSS_API_PORT_HTTPS=${INTERUSS_API_PORT_HTTPS:-8121}
       - STORAGE_API_SERVER=storage_api
       - STORAGE_API_PORT=5000
+      - SSL_CERT_NAME
+      - SSL_KEY_NAME
     depends_on:
       - storage_api
+    restart: always

--- a/datanode/docker/docker-compose_localssl.yaml
+++ b/datanode/docker/docker-compose_localssl.yaml
@@ -15,8 +15,12 @@
 # Modifies base docker-compose data node configuration to use keys present on the host file system.
 
 # Additional required environment variables:
-#   SSL_CERT_PATH: Path to SSL certificate named cert.pem.
-#   SSL_KEY_PATH: Path to SSL private key named key.pem.
+#   SSL_CERT_PATH: Path to SSL certificate named cert.pem, or per SSL_CERT_NAME.
+#   SSL_KEY_PATH: Path to SSL private key named key.pem, or per SSL_KEY_NAME.
+
+# Additional optional environment variables:
+#   SSL_CERT_NAME: File name of SSL certificate (default: cert.pem)
+#   SSL_KEY_NAME: File name of SSL private key (default: key.pem)
 
 # To use this configuration:
 # docker-compose -f docker-compose.yaml -f docker-compose_localssl.yaml -p datanode up
@@ -29,3 +33,6 @@ services:
     volumes:
       - ${SSL_CERT_PATH:?Environment variable SSL_CERT_PATH must be set}:/etc/ssl/certs
       - ${SSL_KEY_PATH:?Environment variable SSL_KEY_PATH must be set}:/etc/ssl/private
+    environment:
+      - SSL_CERT_NAME=${SSL_CERT_NAME:-cert.pem}
+      - SSL_KEY_NAME=${SSL_KEY_NAME:-key.pem}

--- a/datanode/docker/nginx_entrypoint.sh
+++ b/datanode/docker/nginx_entrypoint.sh
@@ -34,8 +34,8 @@ echo "
 
       listen ${INTERUSS_API_PORT_HTTPS:-8121} ssl;
       # server_name         www.example.com;
-      ssl_certificate     /etc/ssl/certs/cert.pem;
-      ssl_certificate_key /etc/ssl/private/key.pem;
+      ssl_certificate     /etc/ssl/certs/${SSL_CERT_NAME:-cert.pem};
+      ssl_certificate_key /etc/ssl/private/${SSL_KEY_NAME:-key.pem};
       ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
       ssl_ciphers         HIGH:!aNULL:!MD5;
 

--- a/datanode/docker/node.sh
+++ b/datanode/docker/node.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file may be adapted to bring up or down a production node in one
+# command. Replace content in ** ** characters with your server-specific
+# information, and see README.md for more information.
+
+if [ "$1" == "" ]; then
+  echo "You must pass in the server ID (1-999)"
+  exit 0
+fi
+echo "Server ID: $1"
+
+export SSL_CERT_PATH=**FULL LOCAL PATH CONTAINING SSL CERTIFICATE**
+export SSL_KEY_PATH=**FULL LOCAL PATH CONTAINING SSL CERTIFICATE KEY**
+export SSL_CERT_NAME=**NAME OF SSL CERTIFICATE FILE (e.g., cert.crt or cert.chained.pem)**
+export SSL_KEY_NAME=**NAME OF SSL KEY FILE (e.g., private.pem or cert.key)**
+
+echo "SSL cert ${SSL_CERT_PATH}/${SSL_KEY_NAME}"
+echo "SSL key ${SSL_KEY_PATH}/${SSL_KEY_NAME}"
+
+export ZOO_MY_ID=$1
+export INTERUSS_PUBLIC_KEY=**PUBLIC KEY OF YOUR AUTH SERVER**
+export ZOO_SERVERS=**YOUR INTERUSS PLATFORM NETWORK CONFIGURATION**
+export ZOO_SERVERS=`echo $ZOO_SERVERS | sed "s/server\.${ZOO_MY_ID}=[^:]*:/server.${ZOO_MY_ID}=0.0.0.0:/"`
+
+echo "ZOO_SERVERS=${ZOO_SERVERS}"
+
+if ! command -v docker-compose; then
+  echo "No docker-compose found; using docker-compose container alias"
+  shopt -s expand_aliases
+  alias docker-compose='printenv > .env; docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD:/rootfs/$PWD" -w="/rootfs/$PWD" docker/compose:1.23.1'
+fi
+
+echo "Downloading the latest deployment files..."
+wget -N https://raw.githubusercontent.com/wing-aviation/InterUSS-Platform/tcl4/datanode/docker/docker-compose.yaml
+wget -N https://raw.githubusercontent.com/wing-aviation/InterUSS-Platform/tcl4/datanode/docker/docker-compose_localssl.yaml
+
+echo "Stopping any existing docker containers..."
+docker-compose -f docker-compose.yaml -f docker-compose_localssl.yaml -p datanode down
+
+echo "Downloading the latest images..."
+docker pull interussplatform/reverse_proxy
+docker pull interussplatform/storage_api:tcl4
+
+echo "Starting the new docker containers..."
+docker-compose -f docker-compose.yaml -f docker-compose_localssl.yaml -p datanode up -d

--- a/datanode/src/updating.md
+++ b/datanode/src/updating.md
@@ -38,6 +38,10 @@ Change the storage_api image to target the new branch.
 
 Change the storage_api image to target the new branch.
 
+### docker/node.sh
+
+Change the deployment file download locations.
+
 ### docker/Dockerfile_storageapi
 
 Also change the `docker image build` and `docker run` comment lines to target


### PR DESCRIPTION
The PR adds a `node.sh` quick deployment script and documentation.  It also updates the docker-compose files to allow specific naming of the SSL certificate files, and adds `restart: always` flags for resilience (mirroring changes in publicportal branch).

There are no changes to functionality outside the slight docker-compose alterations.