### PR TITLE
Augment status endpoint

### DIFF
--- a/datanode/src/storage_api_test.py
+++ b/datanode/src/storage_api_test.py
@@ -21,6 +21,10 @@ import requests
 
 import storage_api
 
+# NOTE: A zookeeper instance must be available for these tests to succeed.
+# To host a suitable zookeeper instance on your local machine, run:
+#   docker run --net=host --rm zookeeper
+
 ZK_TEST_CONNECTION_STRING = 'localhost:2181'
 TESTID = 'storage-api-test'
 
@@ -84,7 +88,7 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
   def testIntrospectWithValidToken(self):
     self.assertIsNotNone(os.environ.get('FIMS_AUTH'))
     self.assertIsNotNone(os.environ.get('INTERUSS_PUBLIC_KEY'))
-    endpoint = 'https://utmalpha.arc.nasa.gov//fimsAuthServer/oauth/token?grant_type=client_credentials'
+    endpoint = 'https://utmalpha.arc.nasa.gov//fimsAuthServer/oauth/token?grant_type=client_credentials&scope=utm.nasa.gov_read.constraint'
     headers = {'Authorization': 'Basic ' + os.environ.get('FIMS_AUTH', '')}
     r = requests.post(endpoint, headers=headers)
     self.assertEqual(200, r.status_code)

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -41,6 +41,7 @@ import slippy_util
 
 # Kazoo is the zookeeper wrapper for python
 from kazoo.client import KazooClient
+from kazoo.exceptions import KazooException
 from kazoo.exceptions import BadVersionError
 from kazoo.exceptions import NoNodeError
 from kazoo.exceptions import RolledBackError
@@ -104,6 +105,15 @@ class USSMetadataManager(object):
   def __del__(self):
     log.debug('Destroying metadata manager object and disconnecting from zk...')
     self.zk.stop()
+
+  def get_state(self):
+    return self.zk.state
+
+  def get_zookeeper_version(self):
+    try:
+      return self.zk.server_version()
+    except KazooException as e:
+      return e.message
 
   def set_verbose(self):
     log.setLevel(logging.DEBUG)

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -109,11 +109,12 @@ class USSMetadataManager(object):
   def get_state(self):
     return self.zk.state
 
-  def get_zookeeper_version(self):
+  def get_version(self):
     try:
-      return self.zk.server_version()
+      return True, self.zk.server_version()
     except KazooException as e:
-      return e.message
+      msg = str(e)
+      return False, type(e).__name__ + (' ' + msg if msg else '')
 
   def set_verbose(self):
     log.setLevel(logging.DEBUG)


### PR DESCRIPTION
This PR improves the `status` endpoint to include more information that is likely to indicate why a node is in poor health including disk usage (if logs have filled up the disk) and connection to the Zookeeper server.