### PR TITLE
Add custom/area-based authorization

### DIFF
--- a/assets/swaggerhub_api.yaml
+++ b/assets/swaggerhub_api.yaml
@@ -78,7 +78,7 @@ paths:
 
   /introspect:
     get:
-      summary: Status checker of an authorization token
+      summary: Checks whether an access token is valid for any of the available authorization authorities.
       produces:
       - application/json
       parameters:
@@ -87,6 +87,82 @@ paths:
         description: Access token to validate
         required: true
         type: string
+      responses:
+        200:
+          description: JSend version of validated access token
+          schema:
+            $ref: '#/definitions/JSendIntrospectResponse'
+        400:
+          description: Invalid/expired token or invalid format
+        403:
+          description: Access token not provided
+
+  /introspect/{zoom}/{x}/{y}:
+    get:
+      summary: Checks whether an access token is valid for an authorization authority appropriate to the specified slippy tile.
+      produces:
+        - application/json
+      parameters:
+        - name: access_token
+          in: header
+          description: Access token to validate
+          required: true
+          type: string
+        - name: zoom
+          in: path
+          description: Zoom level in slippy tile format
+          required: true
+          type: integer
+        - name: x
+          in: path
+          description: x tile number in slippy tile format
+          required: true
+          type: integer
+        - name: y
+          in: path
+          description: y tile number in slippy tile format
+          required: true
+          type: integer
+      responses:
+        200:
+          description: JSend version of validated access token
+          schema:
+            $ref: '#/definitions/JSendIntrospectResponse'
+        400:
+          description: Invalid/expired token or invalid format
+        403:
+          description: Access token not provided
+
+  /introspect/{zoom}:
+    get:
+      summary: Checks whether an access token is valid for an authorization authority appropriate to the specified area.
+      produces:
+        - application/json
+      parameters:
+        - name: access_token
+          in: header
+          description: Access token to validate
+          required: true
+          type: string
+        - name: zoom
+          in: path
+          description: Zoom level in slippy tile format
+          required: true
+          type: integer
+        - name: coords
+          in: query
+          description: CSV list of latitude,longitude,latitude,longitude...
+          required: true
+          type: string
+        - name: coord_type
+          in: query
+          description: Type of query (point, path, or polygon)
+          default: point
+          type: string
+          enum:
+            - point
+            - path
+            - polygon
       responses:
         200:
           description: JSend version of validated access token

--- a/datanode/src/authorization.py
+++ b/datanode/src/authorization.py
@@ -1,0 +1,105 @@
+"""The InterUSS Platform Data Node authorization tools.
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import sys
+from flask import abort
+from flask import Flask
+from flask import jsonify
+from flask import request
+import jwt
+from rest_framework import status
+
+TESTID = None
+
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+log = logging.getLogger('InterUSS_DataNode_Authorization')
+
+
+def SetTestId(testid):
+  global TESTID
+  TESTID = testid
+  log.info('Authorization set to test mode with TESTID=%s' % TESTID)
+
+
+def ValidateAccessToken(zoom=None, tiles=None):
+  """Checks the access token, aborting if it does not pass.
+
+  Uses an Oauth public key to validate an access token.
+
+  Args:
+    zoom: slippy zoom level user is attempting to access
+    tiles: collection of (x,y) slippy tiles user is attempting to access
+
+  Returns:
+    USS identification from OAuth client_id field
+
+  Raises:
+    HTTPException: when the access token is invalid or inappropriate
+  """
+  uss_id = None
+  if ('access_token' in request.headers and TESTID and
+    TESTID in request.headers['access_token']) :
+    uss_id = request.headers['access_token']
+  elif ('Authorization' in request.headers and TESTID and
+        TESTID in request.headers['Authorization']):
+    uss_id = request.headers['Authorization']
+  elif (TESTID and 'access_token' not in request.headers and
+        'Authorization' not in request.headers):
+    uss_id = TESTID
+  else:
+    # TODO(hikevin): Replace with OAuth Discovery and JKWS
+    secret = os.getenv('INTERUSS_PUBLIC_KEY')
+    token = None
+    if 'Authorization' in request.headers:
+      token = request.headers['Authorization'].replace('Bearer ', '')
+    elif 'access_token' in request.headers:
+      token = request.headers['access_token']
+    if secret and token:
+      # ENV variables sometimes don't pass newlines, spec says white space
+      # doesn't matter, but pyjwt cares about it, so fix it
+      secret = secret.replace(' PUBLIC ', '_PLACEHOLDER_')
+      secret = secret.replace(' ', '\n')
+      secret = secret.replace('_PLACEHOLDER_', ' PUBLIC ')
+      try:
+        r = jwt.decode(token, secret, algorithms='RS256')
+        #TODO(hikevin): Check scope is valid for InterUSS Platform
+        uss_id = r['client_id'] if 'client_id' in r else r['sub']
+      except jwt.ExpiredSignatureError:
+        log.error('Access token has expired.')
+        abort(status.HTTP_401_UNAUTHORIZED,
+              'OAuth access_token is invalid: token has expired.')
+      except jwt.DecodeError:
+        log.error('Access token is invalid and cannot be decoded.')
+        abort(status.HTTP_400_BAD_REQUEST,
+              'OAuth access_token is invalid: token cannot be decoded.')
+    else:
+      log.error('Attempt to access resource without access_token in header.')
+      abort(status.HTTP_403_FORBIDDEN,
+            'Valid OAuth access_token must be provided in header.')
+  return uss_id
+
+
+def _VerifyPublicKey():
+  if not os.environ.get('INTERUSS_PUBLIC_KEY'):
+    log.error('INTERUSS_PUBLIC_KEY environment variable must be set.')
+    sys.exit(-1)
+
+
+# Verify that the public key was provided upon loading this library.
+_VerifyPublicKey()

--- a/datanode/src/authorization.py
+++ b/datanode/src/authorization.py
@@ -15,91 +15,347 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import abc
+import json
 import logging
+import numbers
 import os
 import sys
-from flask import abort
-from flask import Flask
-from flask import jsonify
-from flask import request
+import flask
 import jwt
+import requests
 from rest_framework import status
+from shapely.geometry import Polygon
 
-TESTID = None
+import slippy_util
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 log = logging.getLogger('InterUSS_DataNode_Authorization')
 
 
-def SetTestId(testid):
-  global TESTID
-  TESTID = testid
-  log.info('Authorization set to test mode with TESTID=%s' % TESTID)
+def JoinZoom(zoom, tiles):
+  """Combine single zoom and multiple tiles into tile triplets."""
+  return ((zoom, t[0], t[1]) for t in tiles)
 
 
-def ValidateAccessToken(zoom=None, tiles=None):
-  """Checks the access token, aborting if it does not pass.
+class Authorizer(object):
+  """Manages authorization on a per-area basis."""
 
-  Uses an Oauth public key to validate an access token.
+  def __init__(self, public_key, auth_config_string):
+    self.test_id = None
+    self.authorities = []
+    self._cache = {}
+
+    if public_key:
+      log.info('Using global auth provider from single public key')
+      self.authorities.append(
+        _AuthorizationAuthority(public_key, 'Global authority'))
+
+    if auth_config_string:
+      self.authorities.extend(_ParseAuthorities(auth_config_string))
+
+  def SetTestId(self, testid):
+    self.test_id = testid
+    log.info('Authorization set to test mode with test ID=%s' % self.test_id)
+
+  def ValidateAccessToken(self, headers, tiles=None):
+    """Checks the access token, aborting if it does not pass.
+
+    Uses one or more OAuth public keys to validate an access token.
+
+    Args:
+      headers: dict of headers from flask.request
+      tiles: collection of (zoom, x,y) slippy tiles user is attempting to access
+
+    Returns:
+      USS identification from OAuth client_id or sub field
+
+    Raises:
+      HTTPException: when the access token is invalid or inappropriate
+    """
+    uss_id = None
+    if self.test_id:
+      if self.test_id in headers.get('access_token', ''):
+        return headers['access_token']
+      elif self.test_id in headers.get('Authorization', ''):
+        return headers['Authorization']
+      elif 'access_token' not in headers and 'Authorization' not in headers:
+        return self.test_id
+
+    # TODO(hikevin): Replace with OAuth Discovery and JKWS
+    token = None
+    if 'Authorization' in headers:
+      token = headers['Authorization'].replace('Bearer ', '')
+    elif 'access_token' in headers:
+      token = headers['access_token']
+    if not token:
+      log.error('Attempt to access resource without access_token in header.')
+      flask.abort(status.HTTP_403_FORBIDDEN,
+                  'Valid OAuth access_token must be provided in header.')
+
+    # Verify validity of claims without checking signature
+    try:
+      r = jwt.decode(token, algorithms='RS256', verify=False)
+      #TODO(hikevin): Check scope is valid for InterUSS Platform
+      uss_id = r['client_id'] if 'client_id' in r else r.get('sub', None)
+    except jwt.ImmatureSignatureError:
+      log.error('Access token is immature.')
+      flask.abort(status.HTTP_401_UNAUTHORIZED,
+                  'OAuth access_token is invalid: token is immature.')
+    except jwt.ExpiredSignatureError:
+      log.error('Access token has expired.')
+      flask.abort(status.HTTP_401_UNAUTHORIZED,
+                  'OAuth access_token is invalid: token has expired.')
+    except jwt.DecodeError:
+      log.error('Access token is invalid and cannot be decoded.')
+      flask.abort(status.HTTP_400_BAD_REQUEST,
+                  'OAuth access_token is invalid: token cannot be decoded.')
+    except jwt.InvalidTokenError as e:
+      log.error('Unexpected InvalidTokenError: %s', str(e))
+      flask.abort(status.HTTP_500_INTERNAL_SERVER_ERROR,
+                  'Unexpected token error: ' + str(e))
+    issuer = r.get('iss', None)
+
+    if tiles:
+      # Check only authorities that manage all specified tiles
+      authorities = set.intersection(
+          *[self._GetAuthorities(issuer, tile) for tile in tiles])
+    else:
+      authorities = self._GetAuthorities(issuer, None)
+    if not authorities:
+      flask.abort(status.HTTP_401_UNAUTHORIZED,
+                  'No authorization authorities could be found')
+
+    # Check signature against all possible public keys
+    valid = False
+    for authority in authorities:
+      try:
+        jwt.decode(token, authority.public_key, algorithms='RS256')
+        valid = True
+        break
+      except jwt.InvalidSignatureError:
+        # Access token signature not valid for this public key, but might be
+        # valid for a different public key.
+        pass
+    if not valid:
+      # Check against all authorities
+      for authority in self.authorities:
+        try:
+          jwt.decode(token, authority.public_key, algorithms='RS256')
+          invalid_tile = None
+          if tiles:
+            for tile in tiles:
+              if not authority.is_applicable(issuer, tile):
+                invalid_tile = tile
+                break
+          if invalid_tile:
+            flask.abort(
+                status.HTTP_401_UNAUTHORIZED,
+                'Access token has valid signature but %s is not applicable to '
+                'tile %s' % (authority.name, str(invalid_tile)))
+          else:
+            flask.abort(status.HTTP_401_UNAUTHORIZED,
+                        'Access token has valid signature but does not match '
+                        'server\'s authority configuration')
+        except jwt.InvalidSignatureError:
+          # Token signature isn't valid for this authority
+          pass
+      flask.abort(status.HTTP_401_UNAUTHORIZED,
+                  'Access token signature is invalid')
+
+    return uss_id
+
+  def _GetAuthorities(self, issuer, tile):
+    """Retrieve set of applicable AuthorizationAuthorities."""
+    cache_key = (issuer, tile)
+    if cache_key not in self._cache:
+      self._cache[cache_key] = set(a for a in self.authorities
+                                   if a.is_applicable(issuer, tile))
+    return self._cache[cache_key]
+
+
+class _AuthorizationAuthority(object):
+  """Authority that grants access tokens to access part of this data node."""
+
+  def __init__(self, public_key, name):
+    # ENV variables sometimes don't pass newlines, spec says white space
+    # doesn't matter, but pyjwt cares about it, so fix it
+    public_key = public_key.replace(' PUBLIC ', '_PLACEHOLDER_')
+    public_key = public_key.replace(' ', '\n')
+    public_key = public_key.replace('_PLACEHOLDER_', ' PUBLIC ')
+    self.public_key = public_key
+    self.constraints = []
+    self.name = name
+
+  def is_applicable(self, issuer, tile):
+    """Determine whether an AuthorizationAuthority is applicable for tile.
+
+    Args:
+      issuer: Content of access token's `iss` JWT field.
+      tile: Slippy (zoom, x, y) for tile of interest.
+
+    Returns:
+      True if this AuthorizationAuthority is applicable for the specified tile.
+    """
+    if self.constraints:
+      return all(c.is_applicable(issuer, tile) for c in self.constraints)
+    else:
+      return True
+
+
+class _AuthorizationConstraint(object):
+  """Base class for constraints on when an AuthorizationAuthority applies."""
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def is_applicable(self, issuer, tile):
+    """Determine whether an AuthorizationAuthority is applicable for tile.
+
+    Args:
+      issuer: Content of access token's `iss` JWT field.
+      tile: Slippy (zoom, x, y) for tile of interest.
+
+    Returns:
+      True if the associated AuthorizationAuthority is applicable for the
+      specified tile.
+    """
+    raise NotImplementedError('Abstract method is_applicable not implemented')
+
+
+class _IssuerConstraint(_AuthorizationConstraint):
+  """Access token `iss` field must match issuer."""
+
+  def __init__(self, issuer):
+    self._issuer = issuer
+
+  def is_applicable(self, issuer, tile):
+    # Overrides method in parent class.
+    return issuer == self._issuer
+
+
+class _AreaConstraint(_AuthorizationConstraint):
+  """Tiles must lie in or out of an arbitrary geo polygon."""
+
+  def __init__(self, points, inside):
+    self._polygon = Polygon(points)
+    self._inside = inside
+
+  def is_applicable(self, issuer, tile):
+    # Overrides method in parent class.
+    if not tile:
+      return True
+    tile_polygon = Polygon(slippy_util.convert_tile_to_polygon(*tile))
+    if self._inside:
+      return self._polygon.intersects(tile_polygon)
+    else:
+      return not tile_polygon.within(self._polygon)
+
+
+class _RangeConstraint(_AuthorizationConstraint):
+  """Tiles must lie inside one or more explicit Slippy tile ranges."""
+
+  def __init__(self, tile_ranges, inclusive):
+    self._tile_ranges = []
+    for tile_range in tile_ranges:
+      z_range, x_range, y_range = tile_range
+      z_min, z_max = _GetRangeBounds(z_range)
+      x_min, x_max = _GetRangeBounds(x_range)
+      y_min, y_max = _GetRangeBounds(y_range)
+      self._tile_ranges.append((z_min, z_max, x_min, x_max, y_min, y_max))
+    self._inclusive = inclusive
+
+  def is_applicable(self, issuer, tile):
+    # Overrides method in parent class.
+    if not tile:
+      return True
+    zoom, x, y = tile
+    in_range = False
+    for tile_range in self._tile_ranges:
+      z_min, z_max, x_min, x_max, y_min, y_max = tile_range
+      if ((z_min <= zoom <= z_max) and
+          (x_min <= x <= x_max) and
+          (y_min <= y <= y_max)):
+        in_range = True
+        break
+    return in_range == self._inclusive
+
+
+def _GetRangeBounds(range_spec):
+  """Convert a JSON range spec into min and max bounds of that range.
 
   Args:
-    zoom: slippy zoom level user is attempting to access
-    tiles: collection of (x,y) slippy tiles user is attempting to access
+    range_spec: Decoded JSON structure describing range.
+      Number: Value must match specified value exactly.
+      "*": Any value accepted.
+      "XXX:YYY": Any value accepted between XXX and YYY, inclusive.
 
   Returns:
-    USS identification from OAuth client_id field
-
-  Raises:
-    HTTPException: when the access token is invalid or inappropriate
+    min_bound: Minimum inclusive bound of range.
+    max_bound: Maximum inclusive bound of range.
   """
-  uss_id = None
-  if ('access_token' in request.headers and TESTID and
-    TESTID in request.headers['access_token']) :
-    uss_id = request.headers['access_token']
-  elif ('Authorization' in request.headers and TESTID and
-        TESTID in request.headers['Authorization']):
-    uss_id = request.headers['Authorization']
-  elif (TESTID and 'access_token' not in request.headers and
-        'Authorization' not in request.headers):
-    uss_id = TESTID
-  else:
-    # TODO(hikevin): Replace with OAuth Discovery and JKWS
-    secret = os.getenv('INTERUSS_PUBLIC_KEY')
-    token = None
-    if 'Authorization' in request.headers:
-      token = request.headers['Authorization'].replace('Bearer ', '')
-    elif 'access_token' in request.headers:
-      token = request.headers['access_token']
-    if secret and token:
-      # ENV variables sometimes don't pass newlines, spec says white space
-      # doesn't matter, but pyjwt cares about it, so fix it
-      secret = secret.replace(' PUBLIC ', '_PLACEHOLDER_')
-      secret = secret.replace(' ', '\n')
-      secret = secret.replace('_PLACEHOLDER_', ' PUBLIC ')
-      try:
-        r = jwt.decode(token, secret, algorithms='RS256')
-        #TODO(hikevin): Check scope is valid for InterUSS Platform
-        uss_id = r['client_id'] if 'client_id' in r else r['sub']
-      except jwt.ExpiredSignatureError:
-        log.error('Access token has expired.')
-        abort(status.HTTP_401_UNAUTHORIZED,
-              'OAuth access_token is invalid: token has expired.')
-      except jwt.DecodeError:
-        log.error('Access token is invalid and cannot be decoded.')
-        abort(status.HTTP_400_BAD_REQUEST,
-              'OAuth access_token is invalid: token cannot be decoded.')
-    else:
-      log.error('Attempt to access resource without access_token in header.')
-      abort(status.HTTP_403_FORBIDDEN,
-            'Valid OAuth access_token must be provided in header.')
-  return uss_id
+  if isinstance(range_spec, numbers.Number):
+    return range_spec, range_spec
+  elif isinstance(range_spec, basestring):
+    if range_spec == '*':
+      return float('-inf'), float('inf')
+    elif ':' in range_spec:
+      bounds = range_spec.split(':')
+      if len(bounds) != 2:
+        raise ValueError('Too many bounds in range_spec')
+      return int(bounds[0]), int(bounds[1])
+  raise ValueError('Invalid range_spec')
 
 
-def _VerifyPublicKey():
-  if not os.environ.get('INTERUSS_PUBLIC_KEY'):
-    log.error('INTERUSS_PUBLIC_KEY environment variable must be set.')
-    sys.exit(-1)
+def _ParseAuthorities(config_string):
+  """Create a list of AuthorizationAuthorities based on JSON configuration.
 
+  Example JSON:
+  [{"public_key": "-----BEGIN PUBLIC KEY----- ..."},
+   {"name": "Specific area authority",
+    "public_key": "-----BEGIN PUBLIC KEY----- ...",
+    "constraints": [{
+      "type": "issuer",
+      "issuer": "gov.area.authority"}, {
+      "type": "area",
+      "outline": [[30.064,-99.147],[30.054,-99.147],[30.054,-99.134],[30.064,-99.134]],
 
-# Verify that the public key was provided upon loading this library.
-_VerifyPublicKey()
+  Also see authorization_test.py.
+
+  Args:
+    config_string: Configuration description of authorization authorities.
+      If a resource URL (file|http|https://), first load content from URL.
+      Interpreted as JSON per examples.
+
+  Returns:
+    List of AuthorizationAuthorities described in provided config.
+  """
+  if config_string.startswith('file://'):
+    with open(config_string[len('file://'):], 'r') as f:
+      config_string = f.read()
+  if (config_string.startswith('http://') or
+      config_string.startswith('https://')):
+    req = requests.get(config_string)
+    config_string = req.content
+
+  authority_specs = json.loads(config_string)
+  authorities = []
+  for i, authority_spec in enumerate(authority_specs):
+    authority = _AuthorizationAuthority(
+      authority_spec['public_key'],
+      authority_spec.get('name', 'Authority %d' % i))
+    if 'constraints' in authority_spec:
+      for constraint_spec in authority_spec['constraints']:
+        if constraint_spec['type'] == 'issuer':
+          constraint = _IssuerConstraint(constraint_spec['issuer'])
+        elif constraint_spec['type'] == 'area':
+          constraint = _AreaConstraint(
+            constraint_spec['outline'], constraint_spec.get('inside', True))
+        elif constraint_spec['type'] == 'range':
+          constraint = _RangeConstraint(
+            constraint_spec['tiles'], constraint_spec.get('inclusive', True))
+        else:
+          raise ValueError('Invalid constraint type: ' +
+                           constraint_spec.get('type', '<not specified>'))
+        authority.constraints.append(constraint)
+    authorities.append(authority)
+  return authorities

--- a/datanode/src/authorization_test.py
+++ b/datanode/src/authorization_test.py
@@ -1,0 +1,266 @@
+"""Test of the InterUSS Platform Data Node authorization module.
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import collections
+import json
+import os
+import unittest
+import tempfile
+
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+import jwt
+from werkzeug.exceptions import HTTPException
+
+import authorization
+
+KeyPair = collections.namedtuple('KeyPair', 'private_key public_key')
+
+def MakeKeyPair():
+  """Create a public/private RSA key pair.
+
+  Returns:
+    Public and private keys in KeyPair using PEM text format.
+  """
+  key = rsa.generate_private_key(
+    backend=crypto_default_backend(),
+    public_exponent=65537,
+    key_size=2048
+  )
+  private_key = key.private_bytes(
+    crypto_serialization.Encoding.PEM,
+    crypto_serialization.PrivateFormat.PKCS8,
+    crypto_serialization.NoEncryption())
+  public_key = key.public_key().public_bytes(
+    encoding=crypto_serialization.Encoding.PEM,
+    format=crypto_serialization.PublicFormat.SubjectPublicKeyInfo
+  )
+  return KeyPair(private_key, public_key)
+
+
+KEY_PAIRS = {
+  'Global': MakeKeyPair(),
+  'pinecreek.com': MakeKeyPair(),
+  'zion.gov': MakeKeyPair()
+}
+
+CONFIG_CUSTOM_AUTH = json.dumps([
+  {
+    'public_key': KEY_PAIRS['Global'].public_key,
+    'constraints': [
+      {
+        'type': 'range',
+        'tiles': [[14, '*', '*']]
+      }
+    ]
+  }, {
+    'name': 'Pine Creek area authority',
+    'public_key': KEY_PAIRS['pinecreek.com'].public_key,
+    'constraints': [
+      {
+        'type': 'issuer',
+        'issuer': 'pinecreek.com'
+      }, {
+        'type': 'range',
+        'tiles': [[14, '*', '*']],
+        'inclusive': True
+      }, {
+        'type': 'area',
+        'outline': [[37.2167, -112.9584],
+                    [37.2095, -112.9581],
+                    [37.2091, -112.9406],
+                    [37.2172, -112.9311]],
+        'inside': True
+      }]
+  }, {
+    'name': 'Zion canyon authority',
+    'public_key': KEY_PAIRS['zion.gov'].public_key,
+    'constraints': [
+      {
+        'type': 'issuer',
+        'issuer': 'zion.gov'
+      }, {
+        'type': 'range',
+        'tiles': [
+          [14, 3050, '6364:6366'],
+          [14, 3051, '6365:6369'],
+          [14, '3048:3055', '6362:6364']
+        ],
+        'inclusive': True
+      }, {
+        'type': 'range',
+        'tiles': [[14, 3049, 6364]],
+        'inclusive': False
+      }
+    ]
+  }
+])
+
+
+class InterUSSStorageAPITestCase(unittest.TestCase):
+
+  def setUp(self):
+    self.global_auth = authorization.Authorizer(
+        KEY_PAIRS['Global'].public_key, '')
+
+    self.custom_auth_config = tempfile.NamedTemporaryFile(delete=False)
+    self.custom_auth_config.write(CONFIG_CUSTOM_AUTH)
+    self.custom_auth_config.close()
+    self.custom_auth = authorization.Authorizer(
+        '', 'file://' + self.custom_auth_config.name)
+
+  def tearDown(self):
+    os.unlink(self.custom_auth_config.name)
+
+  def assertFails(self, auth, headers, tiles):
+    def validate():
+      auth.ValidateAccessToken(headers, tiles)
+    self.assertRaises(HTTPException, validate)
+
+  def assertSucceeds(self, auth, headers, tiles):
+    uss_id = auth.ValidateAccessToken(headers, tiles)
+    self.assertIsNotNone(uss_id)
+
+  def testGlobalNoToken(self):
+    # Expect failure when no access token is provided
+    self.assertFails(self.global_auth, {}, None)
+    self.assertFails(self.global_auth, {}, ((14, 123, 456),))
+    self.assertFails(self.global_auth, {}, ((14, 123, 456), (14, 124, 456)))
+
+  def testGlobalSuccess(self):
+    # Expect success with a valid access token
+    token = jwt.encode(
+        {'client_id': 'client'}, KEY_PAIRS['Global'].private_key, 'RS256')
+    self.assertSucceeds(self.global_auth, {'access_token': token}, None)
+    self.assertSucceeds(
+        self.global_auth, {'access_token': token}, ((14, 123, 456),))
+    self.assertSucceeds(
+        self.global_auth, {'access_token': token},
+        ((14, 123, 456), (14, 124, 456)))
+
+  def testGlobalCorruptToken(self):
+    # Expect failure with a corrupted access token
+    token = jwt.encode(
+      {'client_id': 'client'}, KEY_PAIRS['Global'].private_key, 'RS256')
+    for i in range(token.find('\n') + 10, len(token)):
+      if token[i] != '0':
+        token = token[0:i] + '0' + token[i+1:]
+        break
+    self.assertFails(self.global_auth, {'access_token': token}, None)
+    self.assertFails(
+        self.global_auth, {'access_token': token}, ((14, 123, 456),))
+    self.assertFails(
+        self.global_auth, {'access_token': token},
+        ((14, 123, 456), (14, 124, 456)))
+
+  def testCustomNoToken(self):
+    # Expect failure when no access token is provided
+    self.assertFails(self.custom_auth, {}, None)
+    self.assertFails(self.custom_auth, {}, ((14, 3051, 6365),))
+    self.assertFails(self.custom_auth, {}, ((14, 3050, 6365), (14, 3051, 6365)))
+
+  def testCustomGlobalSuccess(self):
+    # Expect success authorizing with global authority
+    token = jwt.encode({'client_id': 'client'},
+                       KEY_PAIRS['Global'].private_key, 'RS256')
+    self.assertSucceeds(self.custom_auth, {'access_token': token}, None)
+    self.assertSucceeds(
+      self.custom_auth, {'access_token': token}, ((14, 3051, 6365),))
+    self.assertSucceeds(
+      self.custom_auth, {'access_token': token}, ((14, 3050, 6365),))
+    self.assertSucceeds(
+      self.custom_auth, {'access_token': token},
+      ((14, 3050, 6365), (14, 3051, 6365)))
+    self.assertSucceeds(
+      self.custom_auth, {'access_token': token},
+      ((14, 3051, 6365), (14, 3052, 6365)))
+    self.assertSucceeds(
+      self.custom_auth, {'access_token': token},
+      ((14, 3050, 6365), (14, 3051, 6365), (14, 3052, 6365)))
+
+  def testCustomGlobalFailure(self):
+    # Expect failure authorizing with global authority at wrong zoom
+    token = jwt.encode({'client_id': 'client'},
+                       KEY_PAIRS['Global'].private_key, 'RS256')
+    self.assertFails(
+      self.custom_auth, {'access_token': token},
+      ((13, int(3051/2), int(6365/2)),))
+    self.assertFails(
+      self.custom_auth, {'access_token': token}, ((15, 3051, 6365),))
+    self.assertFails(
+      self.custom_auth, {'access_token': token},
+      ((15, 3050*2, 6365*2), (14, 3051, 6365)))
+
+  def testCustomAreaSuccess(self):
+    # Expect success authorizing with area-based authority
+    token = jwt.encode({'client_id': 'client', 'iss': 'pinecreek.com'},
+                       KEY_PAIRS['pinecreek.com'].private_key, 'RS256')
+    self.assertSucceeds(self.custom_auth, {'access_token': token}, None)
+    self.assertSucceeds(
+        self.custom_auth, {'access_token': token}, ((14, 3051, 6365),))
+    self.assertSucceeds(
+        self.custom_auth, {'access_token': token},
+        ((14, 3051, 6365), (14, 3052, 6365), (14, 3052, 6364)))
+
+  def testCustomAreaFailure(self):
+    # Expect failure authorizing with area-based authority outside area
+    token = jwt.encode({'client_id': 'client', 'iss': 'pinecreek.com'},
+                       KEY_PAIRS['pinecreek.com'].private_key, 'RS256')
+    self.assertFails(
+      self.custom_auth, {'access_token': token}, ((14, 3050, 6365),))
+    self.assertFails(
+      self.custom_auth, {'access_token': token},
+      ((14, 3050, 6365), (14, 3051, 6365)))
+    self.assertFails(
+      self.custom_auth, {'access_token': token},
+      ((14, 3052, 6365), (14, 3053, 6365)))
+
+    # Expect failure with wrong issuer
+    token = jwt.encode({'client_id': 'client', 'iss': 'wrong iss'},
+                       KEY_PAIRS['pinecreek.com'].private_key, 'RS256')
+    self.assertFails(self.custom_auth, {'access_token': token}, None)
+
+  def testCustomRangeSuccess(self):
+    # Expect success authorizing with range-based authority
+    token = jwt.encode({'client_id': 'client', 'iss': 'zion.gov'},
+                       KEY_PAIRS['zion.gov'].private_key, 'RS256')
+    self.assertSucceeds(self.custom_auth, {'access_token': token}, None)
+    self.assertSucceeds(
+      self.custom_auth, {'access_token': token}, ((14, 3051, 6365),))
+    self.assertSucceeds(
+      self.custom_auth, {'access_token': token},
+      ((14, 3050, 6365), (14, 3051, 6365), (14, 3050, 6366)))
+
+  def testCustomRangeFailure(self):
+    # Expect failure authorizing with range-based authority outside area
+    token = jwt.encode({'client_id': 'client', 'iss': 'zion.gov'},
+                       KEY_PAIRS['zion.gov'].private_key, 'RS256')
+    self.assertFails(
+      self.custom_auth, {'access_token': token}, ((14, 3052, 6365),))
+    self.assertFails(
+      self.custom_auth, {'access_token': token},
+      ((14, 3051, 6365), (14, 3052, 6365)))
+
+    # Expect failure with wrong issuer
+    token = jwt.encode({'client_id': 'client', 'iss': 'wrong iss'},
+                       KEY_PAIRS['zion.gov'].private_key, 'RS256')
+    self.assertFails(self.custom_auth, {'access_token': token}, None)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -74,7 +74,8 @@ import slippy_util
 # VERSION = '1.0.2.004'  # slippy non-breaking api changes to support path/polygon
 # VERSION = '1.1.0.005'  # api changes to support multi-grid GET/PUT/DEL
 # VERSION = 'PublicPortal1.1.1.006'  # Added public portal support
-VERSION = 'PublicPortal1.1.1.007'  # Fixed multi-cell bug
+# VERSION = 'PublicPortal1.1.1.007'  # Fixed multi-cell bug
+VERSION = 'PublicPortal1.1.2.008'  # Added per-area auth
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 log = logging.getLogger('InterUSS_DataNode_StorageAPI')

--- a/datanode/src/storage_api_test.py
+++ b/datanode/src/storage_api_test.py
@@ -95,12 +95,19 @@ class InterUSSStorageAPITestCase(unittest.TestCase):
   def testIntrospectWithValidToken(self):
     self.assertIsNotNone(os.environ.get('FIMS_AUTH'))
     self.assertIsNotNone(os.environ.get('INTERUSS_PUBLIC_KEY'))
-    endpoint = 'https://utmalpha.arc.nasa.gov//fimsAuthServer/oauth/token?grant_type=client_credentials'
+    endpoint = 'https://utmalpha.arc.nasa.gov//fimsAuthServer/oauth/token?grant_type=client_credentials&scope=utm.nasa.gov_write.conflictmanagement'
     headers = {'Authorization': 'Basic ' + os.environ.get('FIMS_AUTH', '')}
     r = requests.post(endpoint, headers=headers)
     self.assertEqual(200, r.status_code)
     token = r.json()['access_token']
     result = self.app.get('/introspect', headers={'access_token': token})
+    self.assertEqual(200, result.status_code)
+    result = self.app.get('/introspect/10/223/355', headers={'access_token': token})
+    self.assertEqual(200, result.status_code)
+    result = self.app.get(
+        '/introspect/10?coords=48.832,-101.832,47.954,-101.832,47.954,-100.501,'
+        '48.832,-100.501,48.832,-101.832&coord_type=polygon',
+        headers={'access_token': token})
     self.assertEqual(200, result.status_code)
 
   def testSlippyConversionWithInvalidData(self):


### PR DESCRIPTION
This PR factors out _ValidateAccessToken into an `authorization` module which allows not only the existing solution of providing a single, global public key, but also a custom authorization configuration with multiple overlapping authorization providers and complex applicability specifications.

Additional `introspect` endpoints are added to help troubleshoot any issues that may arise due to complex custom configurations.

The way options are loaded in `storage_api.py` is modified somewhat to always use the ParseOptions method, which uses environment variables as defaults.  This happens to solve questions of whether a command line argument or environment variable would take precedence, but its primary purpose is to ensure that a global `auth` variable in `storage_api.py` is instantiated regardless of the run mode of the `storage_api.py` webserver.