### PR TITLE
Remove HTTP access from nginx configuration

### DIFF
--- a/datanode/docker/Dockerfile_reverseproxy
+++ b/datanode/docker/Dockerfile_reverseproxy
@@ -20,14 +20,13 @@
 # To run this image:
 # docker run \
 #     -e STORAGE_API_SERVER="storage_api_ip" -e STORAGE_API_PORT="5000" \
-#     -p 8121:8121 -p 8120:8120 -d interussplatform/reverse_proxy
+#     -p 8121:8121 -d interussplatform/reverse_proxy
 
 # Required environment variables:
 #   STORAGE_API_SERVER: Address of the storage API service.
 #   STORAGE_API_PORT: Port on which the storage API service is listening.
 
 # Optional environment variables:
-#   INTERUSS_API_PORT_HTTP: Port on which the InterUSS API will be served via HTTP (default 8120).
 #   INTERUSS_API_PORT_HTTPS: Port on which the InterUSS API will be served via HTTPS (default 8121).
 
 FROM nginx
@@ -37,10 +36,8 @@ COPY test_cert.pem /etc/ssl/certs/cert.pem
 COPY test_key.pem /etc/ssl/private/key.pem
 COPY test_signatures .
 
-ENV INTERUSS_API_PORT_HTTP 8120
 ENV INTERUSS_API_PORT_HTTPS 8121
 
 CMD ./nginx_entrypoint.sh
 
-EXPOSE $INTERUSS_API_PORT_HTTP
 EXPOSE $INTERUSS_API_PORT_HTTPS

--- a/datanode/docker/Dockerfile_storageapi
+++ b/datanode/docker/Dockerfile_storageapi
@@ -21,7 +21,7 @@
 # docker run \
 #     -e INTERUSS_CONNECTIONSTRING="zookeeper_ip:2181" \
 #     -e INTERUSS_PUBLIC_KEY="${INTERUSS_PUBLIC_KEY}" \
-#     -p 8121:8121 -d interussplatform/storage_api
+#     -p 8120:8120 -d interussplatform/storage_api
 
 # Required environment variables:
 #   INTERUSS_CONNECTIONSTRING: Set of Zookeeper servers to which the storage API should connect.
@@ -29,7 +29,7 @@
 #   INTERUSS_PUBLIC_KEY: Public key for InterUSS Platform OAuth.
 
 # Optional environment variables:
-#   INTERUSS_API_PORT: Port on which the InterUSS API will be served (default 8121)
+#   INTERUSS_API_PORT: Port on which the InterUSS API will be served via HTTP (default 8120)
 #   INTERUSS_API_SERVER: IP address that will respond to InterUSS API requests (default 0.0.0.0)
 #   INTERUSS_VERBOSE: True for more log messages from the InterUSS API (default true)
 #   INTERUSS_TESTID: Force testing mode with test data located in specific test id
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir python-dateutil kazoo flask PyJWT djangorestframe
 COPY . .
 
 ENV INTERUSS_API_SERVER 0.0.0.0
-ENV INTERUSS_API_PORT 8121
+ENV INTERUSS_API_PORT 8120
 ENV INTERUSS_VERBOSE true
 
 CMD gunicorn storage_api:webapp -b ${INTERUSS_API_SERVER}:${INTERUSS_API_PORT} --access-logfile -

--- a/datanode/docker/README.md
+++ b/datanode/docker/README.md
@@ -17,7 +17,8 @@ requires a separate Zookeeper instance to operate.
 This docker-compose configuration tests the storage API image above by
 instantiating a storage API container along with a connected Zookeeper node in
 stand alone mode. With this system up, the InterUSS Platform storage API is
-exposed on localhost:INTERUSS_API_PORT.
+exposed on http://localhost:INTERUSS_API_PORT where INTERUSS_API_PORT is 8120
+by default.
 
 ### Dockerfile_reverseproxy
 
@@ -27,8 +28,8 @@ gate requests to the storage API and provide HTTPS access to the API.
 ### docker-compose.yaml
 
 This docker-compose configuration brings up an entire InterUSS Platform data
-node in a single command.  By default, HTTP access to the API is available on
-port 8120 and HTTPS on 8121.
+node in a single command.  By default, HTTPS access to the API is available on
+port 8121.
 
 ### docker-compose_localssl.yaml
 
@@ -44,11 +45,11 @@ To run a stand-alone test InterUSS Platform data node that does not synchronize
 with any other data nodes:
 
 ```shell
-export INTERUSS_PUBLIC_KEY=test
+export INTERUSS_PUBLIC_KEY=[valid public key]
 docker-compose -p datanode up
 ```
 
-To verify operation, navigate a browser to http://localhost:8120/status
+To verify operation, navigate a browser to https://localhost:8121/status
 
 To make sure you have the latest versions, first run:
 

--- a/datanode/docker/docker-compose.yaml
+++ b/datanode/docker/docker-compose.yaml
@@ -18,8 +18,6 @@
 #   INTERUSS_PUBLIC_KEY: Public key for InterUSS Platform OAuth.
 
 # Optional environment variables:
-#   INTERUSS_API_PORT_HTTP: Port on which to provide the InterUSS Platform data node API via HTTP
-#     (default 8120).
 #   INTERUSS_API_PORT_HTTPS: Port on which to provide the InterUSS Platform data node API via HTTPS
 #     (default 8121).
 #   ZOO_MY_ID: Zookeeper ID of this node (default 1).
@@ -29,6 +27,7 @@
 #   INTERUSS_TESTID: Force testing mode with test data located in specific test id (if specified).
 
 # To bring up this system:
+# export INTERUSS_PUBLIC_KEY=<your public key>
 # docker-compose -p datanode up
 
 # Note that Zookeeper uses an anonymous volume that allows data to persist between system restarts.
@@ -51,7 +50,7 @@ services:
       - ZOO_SERVERS=${ZOO_SERVERS:-server.1=0.0.0.0:2888:3888}
 
   storage_api:
-    image: interussplatform/storage_api:tcl4
+    image: interussplatform/storage_api
     expose:
       - 5000
     environment:
@@ -66,10 +65,8 @@ services:
   reverse_proxy:
     image: interussplatform/reverse_proxy
     ports:
-      - "${INTERUSS_API_PORT_HTTP:-8120}:${INTERUSS_API_PORT_HTTP:-8120}"
       - "${INTERUSS_API_PORT_HTTPS:-8121}:${INTERUSS_API_PORT_HTTPS:-8121}"
     environment:
-      - INTERUSS_API_PORT_HTTP=${INTERUSS_API_PORT_HTTP:-8120}
       - INTERUSS_API_PORT_HTTPS=${INTERUSS_API_PORT_HTTPS:-8121}
       - STORAGE_API_SERVER=storage_api
       - STORAGE_API_PORT=5000

--- a/datanode/docker/docker-compose_storageapitest.yaml
+++ b/datanode/docker/docker-compose_storageapitest.yaml
@@ -18,9 +18,11 @@
 #   INTERUSS_PUBLIC_KEY: Public key for InterUSS Platform OAuth.
 
 # Optional environment variables:
-#   INTERUSS_API_PORT: Port on which to provide the InterUSS Platform data node API (default 8121).
+#   INTERUSS_API_PORT: Port on which to provide the InterUSS Platform data node API via HTTP
+#                      (default 8120).
 
 # To bring up this system:
+# export INTERUSS_PUBLIC_KEY=<your public key>
 # docker-compose -f docker-compose_storageapitest.yaml -p datanode up
 
 version: '3.6'
@@ -41,9 +43,9 @@ services:
   storage_api:
     image: interussplatform/storage_api
     ports:
-      - "${INTERUSS_API_PORT:-8121}:${INTERUSS_API_PORT:-8121}"
+      - "${INTERUSS_API_PORT:-8120}:${INTERUSS_API_PORT:-8120}"
     environment:
-      - "${INTERUSS_API_PORT:-8121}"
+      - "${INTERUSS_API_PORT:-8120}"
       - INTERUSS_PUBLIC_KEY
       - INTERUSS_CONNECTIONSTRING=zoo:2181
     depends_on:

--- a/datanode/docker/nginx_entrypoint.sh
+++ b/datanode/docker/nginx_entrypoint.sh
@@ -30,8 +30,6 @@ echo "
     underscores_in_headers on;
 
     server {
-      listen ${INTERUSS_API_PORT_HTTP:-8120};
-
       listen ${INTERUSS_API_PORT_HTTPS:-8121} ssl;
       # server_name         www.example.com;
       ssl_certificate     /etc/ssl/certs/cert.pem;


### PR DESCRIPTION
Because the data node authorizes with a reusable access token in the plaintext request header, it is insecure to allow access to the data node via HTTP.  This PR removes HTTP access to the data node via the nginx layer, leaving only HTTPS.

HTTP access to the data node is still possible in development or for special-case configurations not requiring security by exposing the INTERUSS_API_PORT in the storage_api container, or bringing up the system described in docker-compose_storageapitest.yaml rather than the full system in docker-compose.yaml.