### PR TITLE
Record operation details from diagnostic logging tool

### DIFF
--- a/datanode/tools/client_tools.py
+++ b/datanode/tools/client_tools.py
@@ -75,6 +75,19 @@ def get_metadata(token, url):
   return r.content
 
 
+def get_operation(token, uss_baseurl, gufi):
+  """Retrieve details of a single operation from a USS."""
+  url = os.path.join(uss_baseurl, 'operations', gufi)
+  try:
+    response = requests.get(url, headers={
+      'Cache-Control': 'no-cache', 'Authorization': 'Bearer ' + token})
+    return response.content, response.status_code
+  except HTTPError as e:
+    return 'HTTPError: ' + str(e), 500
+  except ValueError as e:
+    return 'ValueError: ' + str(e), 500
+
+
 def add_auth_arguments(parser):
   """Add arguments relating to OAuth authentication.
 

--- a/datanode/tools/client_tools.py
+++ b/datanode/tools/client_tools.py
@@ -16,8 +16,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import collections
+import datetime
 import json
 import os
+import sys
 
 import requests
 import requests.exceptions
@@ -30,29 +33,13 @@ except ImportError:
 DEFAULT_AUTH_URL = 'https://utmalpha.arc.nasa.gov/fimsAuthServer/oauth/token?grant_type=client_credentials'
 DEFAULT_HOST = 'https://node4.tcl4.interussplatform.com:8121/'
 DEFAULT_REQUEST_PATH = 'GridCellsOperator/10?coords=48.832,-101.832,47.954,-101.832,47.954,-100.501,48.832,-100.501,48.832,-101.832&coord_type=polygon'
+EXPIRATION_BUFFER = 5  # seconds
 
+# Access token scope for accessing the InterUSS Platform.
+INTERUSS_SCOPE = 'utm.nasa.gov_write.conflictmanagement'
 
-def get_token(auth_key, auth_url, scope):
-  """Call the specified OAuth server to retrieve an access token.
-
-  Args:
-    auth_key: Base64-encoded username and password.
-    auth_url: URL the provides an access token.
-
-  Returns:
-    Access token for TCL4 InterUSS Platform data node.
-
-  Raises:
-    ValueError: When access_token was not returned properly.
-  """
-  url = auth_url + '&scope=' + scope
-  r = requests.post(url, headers={'Authorization': 'Basic ' + auth_key})
-  result = r.content
-  result_json = json.loads(result)
-  if 'access_token' in result_json:
-    return result_json['access_token']
-  else:
-    raise ValueError('Error getting token: ' + r.content)
+# Access token scope for access individual USSs' operations.
+USS_SCOPE = 'utm.nasa.gov_write.operation'
 
 
 def get_metadata(token, url):
@@ -154,3 +141,73 @@ def make_node_url(options):
   """
   return (options.node + ('' if options.node.endswith('/') else '/') +
           options.request_path)
+
+
+
+CachedToken = collections.namedtuple('CachedToken', ('value', 'expiration'))
+
+
+class TokenManager(object):
+  """Transparently provides access tokens, from cache when possible."""
+
+  def __init__(self, auth_url, auth_key):
+    """Create a TokenManager.
+
+    Args:
+      auth_url: URL the provides an access token.
+      auth_key: Base64-encoded username and password.
+    """
+    if '&scope=' in auth_url:
+      print('USAGE ERROR: The auth URL should now be provided without a scope '
+            'specified in its GET parameters.')
+      sys.exit(1)
+
+    self._auth_url = auth_url
+    self._auth_key = auth_key
+    self._tokens = {}
+
+  def _retrieve_token(self, scope):
+    """Call the specified OAuth server to retrieve an access token.
+
+    Args:
+      scope: Access token scope to request.
+
+    Returns:
+      CachedToken with requested scope.
+
+    Raises:
+      ValueError: When access_token was not returned properly.
+    """
+    url = self._auth_url + '&scope=' + scope
+    r = requests.post(url, headers={'Authorization': 'Basic ' + self._auth_key})
+    result = r.content
+    result_json = json.loads(result)
+    if 'access_token' in result_json:
+      token = result_json['access_token']
+      expires_in = int(result_json.get('expires_in', 0))
+      expiration = (datetime.datetime.utcnow() +
+                    datetime.timedelta(seconds=expires_in - EXPIRATION_BUFFER))
+      return CachedToken(token, expiration)
+    else:
+      raise ValueError('Error getting token: ' + r.content)
+
+  def get_token(self, scope):
+    """Retrieve a current access token with the requested scope.
+
+    Args:
+      scope: Access token scope to request.
+
+    Returns:
+      Access token content.
+
+    Raises:
+      ValueError: When access_token was not returned properly.
+    """
+    if scope in self._tokens:
+      if self._tokens[scope].expiration > datetime.datetime.utcnow():
+        return self._tokens[scope].value
+
+    print('')
+    print('Getting access token for %s...' % scope)
+    self._tokens[scope] = self._retrieve_token(scope)
+    return self._tokens[scope].value

--- a/datanode/tools/monitor
+++ b/datanode/tools/monitor
@@ -100,10 +100,7 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
   # Get an access token
   INTERUSS_SCOPE = 'utm.nasa.gov_write.conflictmanagement'
   USS_SCOPE = 'utm.nasa.gov_write.operation'
-  scopes = [INTERUSS_SCOPE]
-  if record_operations:
-    scopes.append(USS_SCOPE)
-  tokens = {scope: client_tools.get_token(auth_key, auth_url, scope) for scope in scopes}
+  token = client_tools.get_token(auth_key, auth_url, INTERUSS_SCOPE)
 
   old_metadata = {'sync_token': None, 'data': {'operators': []}}
   if output_path:
@@ -121,13 +118,13 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
   while True:
     # Poll metadata, refreshing access_token if necessary
     try:
-      new_metadata_string = client_tools.get_metadata(tokens[INTERUSS_SCOPE], node_url)
+      new_metadata_string = client_tools.get_metadata(token, node_url)
     except ValueError:
       print('')
       print('Access token expired; getting new one...')
-      tokens[INTERUSS_SCOPE] = client_tools.get_token(auth_key, auth_url)
-      print('Updated access token: ' + tokens[INTERUSS_SCOPE])
-      new_metadata_string = client_tools.get_metadata(tokens[INTERUSS_SCOPE], node_url)
+      token = client_tools.get_token(auth_key, auth_url, INTERUSS_SCOPE)
+      print('Updated access token: ' + token)
+      new_metadata_string = client_tools.get_metadata(token, node_url)
 
     new_metadata = json.loads(new_metadata_string)
     if new_metadata['sync_token'] != old_metadata['sync_token']:
@@ -141,19 +138,20 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
         filename = os.path.join(output_path, timestamp + '.json')
         with open(filename, 'w') as f:
           f.write(new_metadata_string)
-        for operator in diff['data']['operators']:
-          for summary in operator['operations']:
-            gufi = summary['gufi']
-            version = summary['version']
-            if gufi in operation_versions and operation_versions[gufi] == version:
-              continue
-            tokens[USS_SCOPE] = client_tools.get_token(auth_key, auth_url, USS_SCOPE)
-            op_string, code = client_tools.get_operation(tokens[USS_SCOPE], operator['uss_baseurl'], gufi)
-            if code == 200:
-              operation_versions[gufi] = version
-            filename = os.path.join(output_path, timestamp + '_' + gufi + '.json')
-            with open(filename, 'w') as f:
-              f.write(op_string)
+        if record_operations:
+          uss_token = client_tools.get_token(auth_key, auth_url, USS_SCOPE)
+          for operator in diff['data']['operators']:
+            for summary in operator['operations']:
+              gufi = summary['gufi']
+              version = summary['version']
+              if gufi in operation_versions and operation_versions[gufi] == version:
+                continue
+              op_string, code = client_tools.get_operation(uss_token, operator['uss_baseurl'], gufi)
+              if code == 200:
+                operation_versions[gufi] = version
+              filename = os.path.join(output_path, timestamp + '_' + gufi + '.json')
+              with open(filename, 'w') as f:
+                f.write(op_string)
 
       old_metadata = new_metadata
 

--- a/datanode/tools/monitor
+++ b/datanode/tools/monitor
@@ -98,7 +98,12 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
   """
 
   # Get an access token
-  token = client_tools.get_token(auth_key, auth_url)
+  INTERUSS_SCOPE = 'utm.nasa.gov_write.conflictmanagement'
+  USS_SCOPE = 'utm.nasa.gov_write.operation'
+  scopes = [INTERUSS_SCOPE]
+  if record_operations:
+    scopes.append(USS_SCOPE)
+  tokens = {scope: client_tools.get_token(auth_key, auth_url, scope) for scope in scopes}
 
   old_metadata = {'sync_token': None, 'data': {'operators': []}}
   if output_path:
@@ -116,13 +121,13 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
   while True:
     # Poll metadata, refreshing access_token if necessary
     try:
-      new_metadata_string = client_tools.get_metadata(token, node_url)
+      new_metadata_string = client_tools.get_metadata(tokens[INTERUSS_SCOPE], node_url)
     except ValueError:
       print('')
       print('Access token expired; getting new one...')
-      token = client_tools.get_token(auth_key, auth_url)
-      print('Updated access token: ' + token)
-      new_metadata_string = client_tools.get_metadata(token, node_url)
+      tokens[INTERUSS_SCOPE] = client_tools.get_token(auth_key, auth_url)
+      print('Updated access token: ' + tokens[INTERUSS_SCOPE])
+      new_metadata_string = client_tools.get_metadata(tokens[INTERUSS_SCOPE], node_url)
 
     new_metadata = json.loads(new_metadata_string)
     if new_metadata['sync_token'] != old_metadata['sync_token']:
@@ -142,7 +147,8 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
             version = summary['version']
             if gufi in operation_versions and operation_versions[gufi] == version:
               continue
-            op_string, code = client_tools.get_operation(token, operator['uss_baseurl'], gufi)
+            tokens[USS_SCOPE] = client_tools.get_token(auth_key, auth_url, USS_SCOPE)
+            op_string, code = client_tools.get_operation(tokens[USS_SCOPE], operator['uss_baseurl'], gufi)
             if code == 200:
               operation_versions[gufi] = version
             filename = os.path.join(output_path, timestamp + '_' + gufi + '.json')

--- a/datanode/tools/monitor
+++ b/datanode/tools/monitor
@@ -97,10 +97,8 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
     record_operations: True to record operation details from USSs when changed.
   """
 
-  # Get an access token
-  INTERUSS_SCOPE = 'utm.nasa.gov_write.conflictmanagement'
-  USS_SCOPE = 'utm.nasa.gov_write.operation'
-  token = client_tools.get_token(auth_key, auth_url, INTERUSS_SCOPE)
+  # Define how to get an access token
+  token_manager = client_tools.TokenManager(auth_url, auth_key)
 
   old_metadata = {'sync_token': None, 'data': {'operators': []}}
   if output_path:
@@ -117,16 +115,10 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
   # Polling loop
   while True:
     # Poll metadata, refreshing access_token if necessary
-    try:
-      new_metadata_string = client_tools.get_metadata(token, node_url)
-    except ValueError:
-      print('')
-      print('Access token expired; getting new one...')
-      token = client_tools.get_token(auth_key, auth_url, INTERUSS_SCOPE)
-      print('Updated access token: ' + token)
-      new_metadata_string = client_tools.get_metadata(token, node_url)
-
+    token = token_manager.get_token(client_tools.INTERUSS_SCOPE)
+    new_metadata_string = client_tools.get_metadata(token, node_url)
     new_metadata = json.loads(new_metadata_string)
+
     if new_metadata['sync_token'] != old_metadata['sync_token']:
       # Data has changed; print out the changes
       print('')
@@ -138,18 +130,27 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
         filename = os.path.join(output_path, timestamp + '.json')
         with open(filename, 'w') as f:
           f.write(new_metadata_string)
+
         if record_operations:
-          uss_token = client_tools.get_token(auth_key, auth_url, USS_SCOPE)
           for operator in diff['data']['operators']:
             for summary in operator['operations']:
               gufi = summary['gufi']
               version = summary['version']
               if gufi in operation_versions and operation_versions[gufi] == version:
                 continue
+              uss_token = token_manager.get_token(client_tools.USS_SCOPE)
               op_string, code = client_tools.get_operation(uss_token, operator['uss_baseurl'], gufi)
-              if code == 200:
-                operation_versions[gufi] = version
+              try:
+                op = json.loads(op_string)
+              except ValueError:
+                op = {}
               filename = os.path.join(output_path, timestamp + '_' + gufi + '.json')
+              if code == 200 and op.get('gufi') == gufi:
+                operation_versions[gufi] = version
+              else:
+                print(termcolor.colored(
+                    'WARNING: Invalid operation from %s with GUFI %s written to %s' %
+                    (operator.get('uss', '???'), gufi, filename)))
               with open(filename, 'w') as f:
                 f.write(op_string)
 

--- a/datanode/tools/monitor
+++ b/datanode/tools/monitor
@@ -34,6 +34,7 @@ import reports
 
 DEFAULT_POLL_INTERVAL = 5  # seconds
 
+
 def print_no_newline(s):
   """Print a string without a trailing newline.
 
@@ -42,6 +43,7 @@ def print_no_newline(s):
   """
   sys.stdout.write(s)
   sys.stdout.flush()
+
 
 def metadata_diff(old_metadata, new_metadata):
   """Return a USS Metadata dict containing only operators different in new relative to old.
@@ -81,7 +83,9 @@ def metadata_diff(old_metadata, new_metadata):
 
   return diff
 
-def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds):
+
+def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds,
+         record_operations):
   """Poll a TCL4 InterUSS Platform node and print and log any changes.
 
   Args:
@@ -90,6 +94,7 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds):
     output_path: Local path to write JSON logs.
     node_url: URL of GridCellOperators TCL4 InterUSS Platform node endpoint.
     poll_interval_seconds: Number of seconds to wait between polling operations.
+    record_operations: True to record operation details from USSs when changed.
   """
 
   # Get an access token
@@ -99,9 +104,11 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds):
   if output_path:
     # Continue from where we left off
     files = sorted(glob.glob(os.path.join(output_path, '*_*.json')))
+    files = [f for f in files if len(f) == len('YYYYMMDD_HHMMSS.json')]
     if files:
       with open(files[-1], 'r') as f:
         old_metadata = json.loads(f.read())
+  operation_versions = {}
 
   first_time = True
 
@@ -121,14 +128,26 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds):
     if new_metadata['sync_token'] != old_metadata['sync_token']:
       # Data has changed; print out the changes
       print('')
-      reports.print_operators(metadata_diff(old_metadata, new_metadata))
+      diff = metadata_diff(old_metadata, new_metadata)
+      reports.print_operators(diff)
 
       if output_path:
-        filename = os.path.join(
-          output_path,
-          datetime.datetime.now().strftime('%Y%m%d_%H%M%S') + '.json')
+        timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+        filename = os.path.join(output_path, timestamp + '.json')
         with open(filename, 'w') as f:
           f.write(new_metadata_string)
+        for operator in diff['data']['operators']:
+          for summary in operator['operations']:
+            gufi = summary['gufi']
+            version = summary['version']
+            if gufi in operation_versions and operation_versions[gufi] == version:
+              continue
+            op_string, code = client_tools.get_operation(token, operator['uss_baseurl'], gufi)
+            if code == 200:
+              operation_versions[gufi] = version
+            filename = os.path.join(output_path, timestamp + '_' + gufi + '.json')
+            with open(filename, 'w') as f:
+              f.write(op_string)
 
       old_metadata = new_metadata
 
@@ -140,6 +159,7 @@ def loop(auth_key, auth_url, output_path, node_url, poll_interval_seconds):
     else:
       print_no_newline('.')
     time.sleep(poll_interval_seconds)
+
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(
@@ -157,12 +177,19 @@ if __name__ == "__main__":
     '-p',
     '--poll_interval',
     dest='poll_interval',
+    type=float,
     default=DEFAULT_POLL_INTERVAL,
     help='Number of seconds to wait in between polling InterUSS Platform node',
     metavar='INTERVAL')
+  parser.add_argument(
+    '--record_operations',
+    dest='record_operations',
+    type=bool,
+    default=False,
+    metavar='RECORD')
   options = parser.parse_args()
 
   node_url = client_tools.make_node_url(options)
 
   loop(options.auth_key, options.auth_url, options.output_path, node_url,
-       options.poll_interval)
+       options.poll_interval, options.record_operations)

--- a/datanode/tools/report
+++ b/datanode/tools/report
@@ -46,7 +46,9 @@ if __name__ == "__main__":
   if options.access_token:
     token = options.access_token
   else:
-    token = client_tools.get_token(options.auth_key, options.auth_url)
+    token_manager = client_tools.TokenManager(
+        options.auth_url, options.auth_key)
+    token = token_manager.get_token(client_tools.INTERUSS_SCOPE)
   node_url = client_tools.make_node_url(options)
   json_string = client_tools.get_metadata(token, node_url)
   metadata = json.loads(json_string)


### PR DESCRIPTION
This PR extends the TCL4 diagnostic `monitor` tool to capture operation details in addition to the grid summaries it previously captured.  To do this, it creates a TokenManager to automatically retrieve and appropriately cache tokens with different scopes, and provides a differently-scoped access token to retrieve operations from USS's than to retrieve the grid state.

This tool was tested successfully during a UPP shakedown.