### PR TITLE
Add explicit zookeeper:3.4 tag in docker config

### DIFF
--- a/datanode/docker/docker-compose.yaml
+++ b/datanode/docker/docker-compose.yaml
@@ -40,7 +40,7 @@ version: '3.6'
 services:
 
   zoo:
-    image: zookeeper
+    image: zookeeper:3.4
     ports:
       - "2888:2888"
       - "3888:3888"


### PR DESCRIPTION
The latest version of the zookeeper image is not backwards-compatible with our implementation; we must explicitly refer to 3.4 to maintain functionality.