### PR TITLE
Replace zookeeper with cockroachdb for testing purposes

### DIFF
--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -108,7 +108,7 @@ class USSMetadataManager(object):
 
     Args:
       connectionstring:
-        cokcroach connection string - following postgres URL syntax
+        cockroach connection string - following postgres URL syntax
       testgroupid:
         ID to use if in test mode, none for normal mode
     """

--- a/datanode/src/storage_interface_test.py
+++ b/datanode/src/storage_interface_test.py
@@ -15,21 +15,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 import threading
 import unittest
 import uuid
 from dateutil import parser
-from kazoo.handlers.threading import KazooTimeoutError
 
 import storage_interface
 import test_utils
 import uss_metadata
 
-# NOTE: A zookeeper instance must be available for these tests to succeed.
-# To host a suitable zookeeper instance on your local machine, run:
-#   docker run --net=host --rm zookeeper
+# NOTE: A cockroach DB instance must be available for these tests to succeed.
+# To host a suitable cockroach instance on your local machine, run:
+#   docker run --rm --name crdb -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v19.1.2 start --insecure
+# Alternatively, you can point the test suite to a remote cockroach instance by setting
+# CRDB_TEST_CONNECTION_STRING in the env of the test.
+CRDB_TEST_CONNECTION_STRING = os.getenv(
+  'CRDB_TEST_CONNECTION_STRING',
+  'host=localhost port=26257 dbname=defaultdb user=root password='
+)
 
-ZK_TEST_CONNECTION_STRING = 'localhost:2181'
 TESTID = 'storage-interface-test-tcl4'
 PARALLEL_WORKERS = 10
 
@@ -42,7 +47,7 @@ class InterUSSStorageInterfaceTestCase(unittest.TestCase):
   def setUp(self):
     # IMPORTANT: Puts us in a test data location
     self.mm = storage_interface.USSMetadataManager(
-        ZK_TEST_CONNECTION_STRING, testgroupid=TESTID)
+        CRDB_TEST_CONNECTION_STRING, testgroupid=TESTID)
     self.mm.set_verbose()
 
   def tearDown(self):


### PR DESCRIPTION
This PR aims to replace zookeeper for cockroachdb for testing purposes. This is a WIP, and meant to gather data and feedback. Important remarks:
- I started over with a very simple database schema, pretty much emulating a KV-store.
- Table creation is done in the ctor of `USSMetadataManager`. Not optimal, but I was hesitant to introduce full-blown schema migration support in the scope of this PR. 
- Tile coordinates still use slippy, and the original pathing is kept in place.
- While zookeeper distinguishes transaction ids and versions, I naively used the transaction timestamp for both in the case of cockroach. Tests seem to be happy, not sure if calling code expects integers, though. If so, we could consider hashing the transaction timestamps (slightly ugly and not monotonically increasing) or introduce a version column.
- In the case of zookeeper, a query for a tile that hasn't been written, yet, still returns a transaction id/version. For cockroach, I adjusted the code to map this case to `None`, adjusting supporting code (in particular hashing multiple transaction ids) to handle the case. Tests seem happy, but feedback is very much appreciated :smile:
- I did not look into optimizing the fast-paths introduced for zookeeper, yet. In particular, the code executes a get before a set and returns early if the relevant tile has been changed in the meantime. We might be able to squeeze out some performance by avoiding the roundtrip to the DB and just rely on our upsert statement.

@BenjaminPelletier mentioning you explicitly to get the PR on your radar.