### PR TITLE
Adjust docs for cockroach

### DIFF
--- a/datanode/src/README.md
+++ b/datanode/src/README.md
@@ -1,12 +1,13 @@
 ## Files of interest:
 
-*   storage_interface.py - Zookeeper Wrapper library in python. It contains
-    one class of interest: USSMetadataManager with get/set/delete operations and
-    an initialization with a Zookeeper connection string.
+*   storage_interface.py - Cockroach Wrapper library in python. It contains one
+    class of interest: USSMetadataManager with get/set/delete operations and an
+    initialization with a connection string following [libpq connection string
+    semantics]{https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING}.
 
 *   uss_metadata.py - information wrapper for the actual JSON data structure.
 
-*   storage_api.py - Web Service API for the Zookeeper library. It will
+*   storage_api.py - Web Service API for the Cockroach library. It will
     start a web service and serve GET/PUT/DELETE on
     /GridCellMetaData/<z>/<x>/<y>, which wraps directly to the
     USSMetadataManager.
@@ -17,7 +18,7 @@
 *   storage_api_test.py - Python unit test for the Web Service API, also
     shows how to use the API to get, set, and delete metadata.
 
-*   storage_interface_test.py - Python unit test for the Zookeeper Wrapper
+*   storage_interface_test.py - Python unit test for the Cockroach Wrapper
     library, also shows how to use the library to get, set, and delete metadata.
 
 
@@ -28,13 +29,13 @@
 *   virtualenv USSenv
 *   cd USSenv
 *   . bin/activate
-*   pip install kazoo flask pytest python-dateutil pyopenssl shapely
+*   pip install flask psycopg2 pytest python-dateutil pyopenssl shapely
 *   pip install requests pyjwt cryptography djangorestframework pytz
 *   ln -sf ../InterUSS-Platform/datanode/src ./src
 *   export INTERUSS_PUBLIC_KEY=(The public KEY for decoding JWTs)
 *   python src/storage_api.py --help
-    *   For example: python src/storage_api.py -z
-        "10.1.0.2:2181,10.1.0.3:2181,10.1.0.4:2181" -s 0.0.0.0 -p 8121 -t
+    *   For example: python src/storage_api.py -c
+        "host=localhost port=26257 dbname=defaultdb user=root password=" -s 0.0.0.0 -p 8121 -t
         test-instance  -v
 
 See also the configurations described in ../docker.

--- a/datanode/src/storage_api.py
+++ b/datanode/src/storage_api.py
@@ -954,11 +954,11 @@ def ParseOptions(argv):
   parser = OptionParser(
       usage='usage: %prog [options]', version='%prog ' + VERSION)
   parser.add_option(
-      '-z',
-      '--zookeeper-servers',
+      '-c',
+      '--crdb',
       dest='connectionstring',
-      help='Specific zookeeper server connection string, '
-      'server:port,server:port...'
+      help='Specific cockroach DB server connection string, '
+      'host=localhost port=26257 dbname=defaultdb user=root password='
       '[or env variable INTERUSS_CONNECTIONSTRING]',
       metavar='CONNECTIONSTRING')
   parser.add_option(

--- a/datanode/src/storage_interface.py
+++ b/datanode/src/storage_interface.py
@@ -53,7 +53,7 @@ log = logging.getLogger('InterUSS_DataNode_InformationInterface')
 USS_BASE_PREFIX = '/uss/gridcells/'
 TEST_BASE_PREFIX = '/test/'
 USS_METADATA_FILE = '/manifest'
-DEFAULT_CONNECTION = 'localhost:2181'
+DEFAULT_CONNECTION = 'host=localhost port=26257 dbname=defaultdb user=root password='
 GRID_PATH = USS_BASE_PREFIX
 MAX_SAFE_INTEGER = 9007199254740991
 DELETE_ATTEMPTS = 3


### PR DESCRIPTION
This is a WIP right now, accumulating documentation (adjustments) for running an instance of the API talking to one or many cockroach DB nodes. Open work items:
- [ ] Provide documentation and examples for client certificate usage
- [ ] Adjust the docker compose setup and relevant documentation
- [ ] Maybe provide a simple helm chart