### PR TITLE
fix "RuntimeError: generator raised StopIteration" in python 3.7

### DIFF
--- a/datanode/src/slippy_util.py
+++ b/datanode/src/slippy_util.py
@@ -304,4 +304,7 @@ def _pairwise(it):
   """Iterator for sets of lon,lat in an array."""
   it = iter(it)
   while True:
-    yield next(it), next(it)
+    try:
+      yield next(it), next(it)
+    except StopIteration:
+      return


### PR DESCRIPTION
PEP 479 is enabled for all code in Python 3.7, meaning that StopIteration exceptions raised directly or indirectly in coroutines and generators are transformed into RuntimeError exceptions.

This fix gets us one step closer to python 3 compatibility (at least for >=3.7 :pizza:).

I tested it with python 2.7 & 3.7